### PR TITLE
mvv-lva move ordering

### DIFF
--- a/engine/move.go
+++ b/engine/move.go
@@ -5,8 +5,9 @@ package engine
 6-11: to square
 12-13: promotion piece (knight, bishop, rook, queen)
 14-15: castling (01), en passant (10), promotion (11)
+16+: move score
 */
-type Move uint16
+type Move uint32
 
 const (
 	NoneFlag = iota << 14
@@ -77,6 +78,15 @@ func (m Move) IsEnPassant() bool {
 
 func (m Move) Type() int {
 	return int(m & PromotionFlag)
+}
+
+func (m Move) Score() int {
+	return int(m&0xffff0000) >> 16
+}
+
+func (m *Move) GiveScore(score int) {
+	*m &= 0xffff
+	*m |= Move(score << 16)
 }
 
 func (m Move) ToString() string {

--- a/engine/move_test.go
+++ b/engine/move_test.go
@@ -1,0 +1,20 @@
+package engine_test
+
+import (
+	"silverfish/engine"
+	"testing"
+)
+
+// rn2kb1r/pp3ppp/2p1pn2/3p3b/8/1P1P1NPP/PBPqPPB1/RN2K2R w KQkq - 0 9
+
+func TestGiveScore(t *testing.T) {
+	move1 := engine.NewMoveFromStr("g2d2")
+	move2 := move1
+	move2.GiveScore(100)
+	if move2.Score() != 100 {
+		t.Errorf(`TestGiveScore: "Score": expected %d, got %d`, 100, move2.Score())
+	}
+	if move1.To() != move2.To() {
+		t.Errorf(`TestGiveScore: "To": expected %d, got %d`, move1.To(), move2.To())
+	}
+}


### PR DESCRIPTION
reordering each depth of iterative deepening + in quiescence search

```
Results of Silverfish-dev vs Silverfish-0.1 (10+0.1, NULL, NULL, 8moves_v3.pgn): Elo: 35.74 +/- 14.05, nElo: 87.28 +/- 34.05 LOS: 100.00 %, DrawRatio: 65.50 %, PairsRatio: 3.60 Games: 400, Wins: 57, Losses: 16, Draws: 327, Points: 220.5 (55.12 %) Ptnml(0-2): [0, 15, 131, 52, 2], WL/DD Ratio: 0.01 LLR: 1.27 (43.1%) (-2.94, 2.94) [0.00, 5.00]
```