### PR TITLE
handle stalemate correctly

### DIFF
--- a/engine/search.go
+++ b/engine/search.go
@@ -185,6 +185,8 @@ func alphaBetaInner(pos *Position, alpha, beta int32, depth int, nodes *int, sta
 	ScoreMoves(pos, &moveList)
 	OrderMoves(pos, &moveList)
 
+	hasLegal := false
+
 	if moveList.Count == 0 {
 		if pos.Checkers(pos.Turn) != 0 {
 			// checkmate
@@ -206,6 +208,7 @@ func alphaBetaInner(pos *Position, alpha, beta int32, depth int, nodes *int, sta
 		if !pos.MoveIsLegal(move) {
 			continue
 		}
+		hasLegal = true
 
 		*nodes++
 
@@ -232,6 +235,16 @@ func alphaBetaInner(pos *Position, alpha, beta int32, depth int, nodes *int, sta
 				score:    bestScore,
 				hasScore: true,
 			})
+		}
+	}
+
+	// GenMoves returns a list of valid but possibly illegal (leaves king in check) moves
+	// avoid the case where all moves are illegal (stalemate/checkmate) but moveList.Count != 0
+	if !hasLegal {
+		if pos.Checkers(pos.Turn) != 0 {
+			return -Infinity
+		} else {
+			return 0
 		}
 	}
 


### PR DESCRIPTION
Give stalemate an accurate score of 0 (instead of -Infinity) in alphaBetaInner

Avoids taking stalemates when we are winning since a stalemate is no longer viewed as a win for us

```
Results of Silverfish-dev vs Silverfish-nnue (10+0.1, NULL, NULL, 8moves_v3.pgn):
Elo: 6.40 +/- 4.25, nElo: 11.56 +/- 7.67
LOS: 99.84 %, DrawRatio: 53.56 %, PairsRatio: 1.14
Games: 7876, Wins: 1470, Losses: 1325, Draws: 5081, Points: 4010.5 (50.92 %)
Ptnml(0-2): [85, 770, 2109, 863, 111], WL/DD Ratio: 0.22
LLR: 2.95 (100.3%) (-2.94, 2.94) [0.00, 5.00]
--------------------------------------------------
SPRT ([0.00, 5.00]) completed - H1 was accepted

Player: Silverfish-dev
  Timeouts: 1
  Crashed: 0
Player: Silverfish-nnue
  Timeouts: 5
  Crashed: 0
```

(todo: detect threefolds)