### PR TITLE
Refactor: honest tests, NNUE load-once, UCI cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-# No easy way to test these, so only kept as "manual inspection" tests locally
-evaluation_test.go
-search_test.go
-
 # various .nnue models (alternative models or models for testing)
 models/
 

--- a/cmd/silverfish/main.go
+++ b/cmd/silverfish/main.go
@@ -58,7 +58,7 @@ func executeGoCommand(channel chan bool, position *engine.Position, command *eng
 		MaxDepth:  depth,
 		TimeLimit: moveTime,
 	}
-	search.Init(*position)
+	search.Init(position)
 
 	var bestMove engine.Move
 	_, bestMove = search.Search()
@@ -127,7 +127,7 @@ mainloop:
 			case engine.UciIsReadyClientMessage:
 				engine.UciReadyOk()
 			case engine.UciPositionClientMessage:
-				position = *message.Position
+				position = message.Position.Clone()
 			case engine.UciQuitClientMessage:
 				break mainloop
 			case engine.UciGoClientMessage:

--- a/cmd/silverfish/main.go
+++ b/cmd/silverfish/main.go
@@ -39,19 +39,29 @@ func executeGoCommand(channel chan bool, position *engine.Position, command *eng
 		return
 	}
 
-	var bestMove engine.Move
+	depth := engine.InfiniteDepth
+	moveTime := engine.InfiniteMovetime
+	switch {
+	case command.Infinite:
+		// keep defaults
 
-	if command.Infinite {
-		// We set a limited depth to avoid stack overflow (as we are using recursion
-		// to implement the search right now)
-		_, bestMove = engine.Search(position, engine.InfiniteDepth, engine.InfiniteMovetime)
-	} else if command.Movetime != 0 {
-		_, bestMove = engine.Search(position, engine.InfiniteDepth, time.Duration(command.Movetime)*time.Millisecond)
-	} else if command.Depth != 0 {
-		_, bestMove = engine.Search(position, int(command.Depth), engine.InfiniteMovetime)
-	} else {
-		_, bestMove = engine.Search(position, engine.InfiniteDepth, engine.TimeLimit(position, command)*time.Millisecond)
+	case command.Movetime != 0:
+		moveTime = time.Duration(command.Movetime) * time.Millisecond
+
+	case command.Depth != 0:
+		depth = int(command.Depth)
+
+	default:
+		moveTime = engine.TimeLimit(position, command) * time.Millisecond
 	}
+	search := engine.Search{
+		MaxDepth:  depth,
+		TimeLimit: moveTime,
+	}
+	search.Init(*position)
+
+	var bestMove engine.Move
+	_, bestMove = search.Search()
 
 	engine.UciBestMove(bestMove)
 

--- a/cmd/silverfish/main.go
+++ b/cmd/silverfish/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime/pprof"
 	"silverfish/engine"
+	"strings"
 	"time"
 )
 
@@ -102,27 +103,23 @@ func main() {
 
 mainloop:
 	for {
-		message := engine.UciClientMessage{}
 		select {
-		case message = <-messageChannel:
-		default:
-			continue
-		}
-
-		if active {
-			select {
-			case <-actionAlertChannel:
-				active = false
-			default:
-				// Do nothing :ye:
+		case message := <-messageChannel:
+			if active {
+				// A search goroutine is running. Only quit is handled here;
+				// everything else (including stop) is dropped, since Search
+				// has no cancellation mechanism yet.
+				if message.MessageType == engine.UciQuitClientMessage {
+					break mainloop
+				}
+				continue
 			}
-		} else {
+
 			switch message.MessageType {
 			case engine.UciUciClientMessage:
 				engine.UciSetEngineName("Silverfish 0.0.0a")
 				engine.UciSetAuthor("李能和赵梁越")
-				engine.UciSetProtocol(2)
-
+				engine.UciOptions()
 				engine.UciOk()
 			case engine.UciIsReadyClientMessage:
 				engine.UciReadyOk()
@@ -131,8 +128,36 @@ mainloop:
 			case engine.UciQuitClientMessage:
 				break mainloop
 			case engine.UciGoClientMessage:
+				active = true
 				go executeGoCommand(actionAlertChannel, &position, message.GoMessage)
+			case engine.UciSetOptionClientMessage:
+				handleSetOption(message.SetOption, &position)
 			}
+
+		case <-actionAlertChannel:
+			active = false
 		}
 	}
+}
+
+func handleSetOption(opt *engine.UciSetOptionMessage, position *engine.Position) {
+	if opt == nil || !strings.EqualFold(opt.Name, "EvalFile") {
+		return
+	}
+
+	path := opt.Value
+	if path == "<empty>" {
+		path = ""
+	}
+
+	if err := engine.LoadDefaultNetwork(path); err != nil {
+		engine.UciError(fmt.Sprintf("failed to load EvalFile %q: %v", opt.Value, err))
+		return
+	}
+
+	// The current position's accumulator was built from the old network,
+	// so it can't just be re-pointed at the new one -- reset to a position
+	// built with the newly-loaded default network. GUIs always send a
+	// `position` command before the next `go`.
+	*position = engine.StartingPosition()
 }

--- a/engine/evaluation.go
+++ b/engine/evaluation.go
@@ -203,7 +203,7 @@ func EvaluateHCE(pos *Position) int32 {
 }
 
 func EvaluateNNUE(pos *Position) int32 {
-	return int32(pos.Nnue.Evaluate(pos.Turn) * 1000)
+	return int32(pos.Acc.Evaluate(pos.Net, pos.Turn) * 1000)
 }
 
 func Evaluate(pos *Position) int32 {

--- a/engine/evaluation_test.go
+++ b/engine/evaluation_test.go
@@ -1,0 +1,35 @@
+package engine_test
+
+import (
+	"testing"
+
+	"silverfish/engine"
+)
+
+// EvaluateHCE reports the score relative to the side to move, so flipping
+// Turn on an otherwise-unchanged position must exactly negate the result.
+// This holds regardless of how the material/PST tables are tuned, unlike
+// asserting hardcoded centipawn values.
+//
+// EvaluateHCE is currently unused by Evaluate (which calls EvaluateNNUE) but
+// is kept as a manually selectable evaluation, so it stays covered.
+func TestEvaluateHCESideToMoveSymmetry(t *testing.T) {
+	fens := []string{
+		"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+		"r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+		"8/8/8/4k3/8/4K3/4P3/8 w - - 0 1",
+		"r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1",
+	}
+
+	for _, fen := range fens {
+		pos := engine.FromFEN(fen)
+
+		white := engine.EvaluateHCE(&pos)
+		pos.Turn = engine.Black
+		black := engine.EvaluateHCE(&pos)
+
+		if white != -black {
+			t.Errorf("EvaluateHCE(%q): white-to-move = %d, black-to-move = %d; want negation", fen, white, black)
+		}
+	}
+}

--- a/engine/init.go
+++ b/engine/init.go
@@ -6,6 +6,31 @@ import (
 
 var Rng *rand.Rand = rand.New(rand.NewSource(123))
 
+var defaultNet *Network
+
 func Init() {
 	InitBitboard()
+	if err := LoadDefaultNetwork(""); err != nil {
+		panic("engine: failed to load default NNUE network: " + err.Error())
+	}
+}
+
+// LoadDefaultNetwork loads path ("" for the embedded default) and installs
+// it as the network used by newly-created Positions (FromFEN, NewPosition).
+// Positions already holding a *Network keep using it -- swapping this only
+// affects positions created afterward. Must only be called from the UCI
+// main loop's idle state (not while a search goroutine is running) since
+// there is no synchronization on the read in NewPosition/FromFEN.
+func LoadDefaultNetwork(path string) error {
+	net, err := LoadNNUE(path)
+	if err != nil {
+		return err
+	}
+	defaultNet = net
+	return nil
+}
+
+// DefaultNetwork returns the network currently installed by Init/LoadDefaultNetwork.
+func DefaultNetwork() *Network {
+	return defaultNet
 }

--- a/engine/main_test.go
+++ b/engine/main_test.go
@@ -1,0 +1,13 @@
+package engine_test
+
+import (
+	"os"
+	"testing"
+
+	"silverfish/engine"
+)
+
+func TestMain(m *testing.M) {
+	engine.Init()
+	os.Exit(m.Run())
+}

--- a/engine/movegen_test.go
+++ b/engine/movegen_test.go
@@ -391,7 +391,3 @@ func TestCastlingMoves(t *testing.T) {
 		fmt.Println()
 	}
 }
-
-func init() {
-	engine.InitBitboard()
-}

--- a/engine/nnue.go
+++ b/engine/nnue.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -47,23 +49,34 @@ func FeatureIndex(perspective uint8, pieceColor uint8, pieceType uint8, sq Squar
 	return 64*uint16(pieceIdx) + uint16(sq)
 }
 
-func LoadNNUE(path string) (*NNUE, error) {
-	// resolve path (either user-provided or embedded default written to a temp file)
-	resolvedPath, cleanup, err := resolveNNUEPath(path)
-	if err != nil {
-		return nil, err
-	}
-	// remove temp file (if any) when done
-	if cleanup != nil {
-		defer cleanup()
-	}
-
-	f, err := os.Open(resolvedPath)
+// LoadNNUEFile loads a network from a file on disk.
+func LoadNNUEFile(path string) (*NNUE, error) {
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
+	return loadNNUEFromReader(bufio.NewReader(f))
+}
 
+// LoadEmbeddedNNUE loads the default network built into the binary.
+func LoadEmbeddedNNUE() (*NNUE, error) {
+	data, err := embeddedNNUEBytes()
+	if err != nil {
+		return nil, err
+	}
+	return loadNNUEFromReader(bytes.NewReader(data))
+}
+
+// LoadNNUE loads the network at path, or the embedded default if path is empty.
+func LoadNNUE(path string) (*NNUE, error) {
+	if path == "" {
+		return LoadEmbeddedNNUE()
+	}
+	return LoadNNUEFile(path)
+}
+
+func loadNNUEFromReader(f io.Reader) (*NNUE, error) {
 	// header
 	magic := make([]byte, 4)
 	if _, err := io.ReadFull(f, magic); err != nil {
@@ -92,6 +105,14 @@ func LoadNNUE(path string) (*NNUE, error) {
 
 	numInputs := int(numInputs32)
 	l1 := int(l132)
+
+	// the accumulator update loops are unrolled in steps of 16
+	if numInputs <= 0 {
+		return nil, fmt.Errorf("invalid NNUE header: numInputs must be positive, got %d", numInputs)
+	}
+	if l1 <= 0 || l1%16 != 0 {
+		return nil, fmt.Errorf("invalid NNUE header: L1 must be a positive multiple of 16, got %d", l1)
+	}
 
 	nnue := &NNUE{
 		NumInputs: numInputs,

--- a/engine/nnue.go
+++ b/engine/nnue.go
@@ -15,7 +15,10 @@ const (
 	Version = 1
 )
 
-type NNUE struct {
+// Network holds NNUE weights loaded from a file. It is immutable once
+// loaded and safe to share across Positions; per-position evaluation state
+// lives in Accumulator instead.
+type Network struct {
 	NumInputs int
 	L1        int
 
@@ -25,10 +28,10 @@ type NNUE struct {
 	BOutput float32
 
 	FeatureCols [][]float32
-
-	Acc Accumulator
 }
 
+// Accumulator is the mutable per-position NNUE evaluation state: one
+// running sum of active feature columns per perspective.
 type Accumulator struct {
 	Values [2][]float32
 }
@@ -50,7 +53,7 @@ func FeatureIndex(perspective uint8, pieceColor uint8, pieceType uint8, sq Squar
 }
 
 // LoadNNUEFile loads a network from a file on disk.
-func LoadNNUEFile(path string) (*NNUE, error) {
+func LoadNNUEFile(path string) (*Network, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -60,7 +63,7 @@ func LoadNNUEFile(path string) (*NNUE, error) {
 }
 
 // LoadEmbeddedNNUE loads the default network built into the binary.
-func LoadEmbeddedNNUE() (*NNUE, error) {
+func LoadEmbeddedNNUE() (*Network, error) {
 	data, err := embeddedNNUEBytes()
 	if err != nil {
 		return nil, err
@@ -69,14 +72,14 @@ func LoadEmbeddedNNUE() (*NNUE, error) {
 }
 
 // LoadNNUE loads the network at path, or the embedded default if path is empty.
-func LoadNNUE(path string) (*NNUE, error) {
+func LoadNNUE(path string) (*Network, error) {
 	if path == "" {
 		return LoadEmbeddedNNUE()
 	}
 	return LoadNNUEFile(path)
 }
 
-func loadNNUEFromReader(f io.Reader) (*NNUE, error) {
+func loadNNUEFromReader(f io.Reader) (*Network, error) {
 	// header
 	magic := make([]byte, 4)
 	if _, err := io.ReadFull(f, magic); err != nil {
@@ -114,150 +117,177 @@ func loadNNUEFromReader(f io.Reader) (*NNUE, error) {
 		return nil, fmt.Errorf("invalid NNUE header: L1 must be a positive multiple of 16, got %d", l1)
 	}
 
-	nnue := &NNUE{
+	net := &Network{
 		NumInputs: numInputs,
 		L1:        l1,
 	}
 
 	// read network parameters
-	nnue.WInput = make([]float32, l1*numInputs)
-	nnue.BInput = make([]float32, l1)
-	nnue.WOutput = make([]float32, 2*l1)
+	net.WInput = make([]float32, l1*numInputs)
+	net.BInput = make([]float32, l1)
+	net.WOutput = make([]float32, 2*l1)
 
-	if err := binary.Read(f, binary.LittleEndian, &nnue.WInput); err != nil {
+	if err := binary.Read(f, binary.LittleEndian, &net.WInput); err != nil {
 		return nil, err
 	}
-	if err := binary.Read(f, binary.LittleEndian, &nnue.BInput); err != nil {
+	if err := binary.Read(f, binary.LittleEndian, &net.BInput); err != nil {
 		return nil, err
 	}
-	if err := binary.Read(f, binary.LittleEndian, &nnue.WOutput); err != nil {
+	if err := binary.Read(f, binary.LittleEndian, &net.WOutput); err != nil {
 		return nil, err
 	}
-	if err := binary.Read(f, binary.LittleEndian, &nnue.BOutput); err != nil {
+	if err := binary.Read(f, binary.LittleEndian, &net.BOutput); err != nil {
 		return nil, err
 	}
 
 	// build helper representation of first layer's weights
-	nnue.BuildFeatureCols()
+	net.buildFeatureCols()
 
-	// allocate accumulators for both sides
-	nnue.Acc.Values[0] = make([]float32, l1)
-	nnue.Acc.Values[1] = make([]float32, l1)
-
-	return nnue, nil
+	return net, nil
 }
 
-// must be called first before using anything
-func (nnue *NNUE) BuildFeatureCols() {
-	numInputs := int(nnue.NumInputs)
-	l1 := int(nnue.L1)
+func (net *Network) buildFeatureCols() {
+	numInputs := net.NumInputs
+	l1 := net.L1
 	cols := make([][]float32, numInputs)
 	for f := 0; f < numInputs; f++ {
 		col := make([]float32, l1)
 		for o := 0; o < l1; o++ {
-			col[o] = nnue.WInput[o*numInputs+f]
+			col[o] = net.WInput[o*numInputs+f]
 		}
 		cols[f] = col
 	}
-	nnue.FeatureCols = cols
+	net.FeatureCols = cols
 }
 
-// add a whole set of initial features (overwriting existing features).
-// this is the only place where input bias is added
-func (nnue *NNUE) Refresh(features []uint16, perspective uint8) {
-	acc := nnue.Acc.Values[perspective]
-	copy(acc, nnue.BInput)
+// NewAccumulator allocates a zeroed accumulator sized for net.
+func NewAccumulator(net *Network) Accumulator {
+	return Accumulator{
+		Values: [2][]float32{
+			make([]float32, net.L1),
+			make([]float32, net.L1),
+		},
+	}
+}
+
+// Clone returns a deep copy, safe to mutate independently of the original.
+func (acc Accumulator) Clone() Accumulator {
+	if acc.Values[White] == nil && acc.Values[Black] == nil {
+		return Accumulator{}
+	}
+	clone := Accumulator{
+		Values: [2][]float32{
+			make([]float32, len(acc.Values[White])),
+			make([]float32, len(acc.Values[Black])),
+		},
+	}
+	copy(clone.Values[White], acc.Values[White])
+	copy(clone.Values[Black], acc.Values[Black])
+	return clone
+}
+
+// Reset installs net's input bias into both perspectives, discarding any
+// active features. This must be done before the first Add/Remove call --
+// Add/Remove alone never add bias.
+func (acc *Accumulator) Reset(net *Network) {
+	copy(acc.Values[White], net.BInput)
+	copy(acc.Values[Black], net.BInput)
+}
+
+// Refresh overwrites one perspective with net's bias plus the given active features.
+func (acc *Accumulator) Refresh(net *Network, features []uint16, perspective uint8) {
+	a := acc.Values[perspective]
+	copy(a, net.BInput)
 	for _, f := range features {
-		col := nnue.FeatureCols[f]
-		for o := 0; o < len(acc); o += 16 {
-			acc[o] += col[o]
-			acc[o+1] += col[o+1]
-			acc[o+2] += col[o+2]
-			acc[o+3] += col[o+3]
-			acc[o+4] += col[o+4]
-			acc[o+5] += col[o+5]
-			acc[o+6] += col[o+6]
-			acc[o+7] += col[o+7]
-			acc[o+8] += col[o+8]
-			acc[o+9] += col[o+9]
-			acc[o+10] += col[o+10]
-			acc[o+11] += col[o+11]
-			acc[o+12] += col[o+12]
-			acc[o+13] += col[o+13]
-			acc[o+14] += col[o+14]
-			acc[o+15] += col[o+15]
+		col := net.FeatureCols[f]
+		for o := 0; o < len(a); o += 16 {
+			a[o] += col[o]
+			a[o+1] += col[o+1]
+			a[o+2] += col[o+2]
+			a[o+3] += col[o+3]
+			a[o+4] += col[o+4]
+			a[o+5] += col[o+5]
+			a[o+6] += col[o+6]
+			a[o+7] += col[o+7]
+			a[o+8] += col[o+8]
+			a[o+9] += col[o+9]
+			a[o+10] += col[o+10]
+			a[o+11] += col[o+11]
+			a[o+12] += col[o+12]
+			a[o+13] += col[o+13]
+			a[o+14] += col[o+14]
+			a[o+15] += col[o+15]
 		}
 	}
 }
 
-// refresh both perspectives
-func (nnue *NNUE) RefreshAll(featuresW, featuresB []uint16) {
-	nnue.Refresh(featuresW, White)
-	nnue.Refresh(featuresB, Black)
+// RefreshAll overwrites both perspectives with net's bias plus their active features.
+func (acc *Accumulator) RefreshAll(net *Network, featuresW, featuresB []uint16) {
+	acc.Refresh(net, featuresW, White)
+	acc.Refresh(net, featuresB, Black)
 }
 
-// incrementally add a feature
-// NOTE: only using Add() is incorrect, since no bias is added
-// remember to also to perform an empty refresh? (ex: in FromFEN)
-func (nnue *NNUE) Add(feature uint16, perspective uint8) {
-	col := nnue.FeatureCols[feature]
-	acc := nnue.Acc.Values[perspective]
-	for o := 0; o < len(acc); o += 16 {
-		acc[o] += col[o]
-		acc[o+1] += col[o+1]
-		acc[o+2] += col[o+2]
-		acc[o+3] += col[o+3]
-		acc[o+4] += col[o+4]
-		acc[o+5] += col[o+5]
-		acc[o+6] += col[o+6]
-		acc[o+7] += col[o+7]
-		acc[o+8] += col[o+8]
-		acc[o+9] += col[o+9]
-		acc[o+10] += col[o+10]
-		acc[o+11] += col[o+11]
-		acc[o+12] += col[o+12]
-		acc[o+13] += col[o+13]
-		acc[o+14] += col[o+14]
-		acc[o+15] += col[o+15]
+// Add incrementally adds a feature. NOTE: only using Add() is incorrect
+// since no bias is added -- Reset() (or RefreshAll) must run first.
+func (acc *Accumulator) Add(net *Network, feature uint16, perspective uint8) {
+	col := net.FeatureCols[feature]
+	a := acc.Values[perspective]
+	for o := 0; o < len(a); o += 16 {
+		a[o] += col[o]
+		a[o+1] += col[o+1]
+		a[o+2] += col[o+2]
+		a[o+3] += col[o+3]
+		a[o+4] += col[o+4]
+		a[o+5] += col[o+5]
+		a[o+6] += col[o+6]
+		a[o+7] += col[o+7]
+		a[o+8] += col[o+8]
+		a[o+9] += col[o+9]
+		a[o+10] += col[o+10]
+		a[o+11] += col[o+11]
+		a[o+12] += col[o+12]
+		a[o+13] += col[o+13]
+		a[o+14] += col[o+14]
+		a[o+15] += col[o+15]
 	}
 }
 
-// incrementally remove a feature
-func (nnue *NNUE) Remove(feature uint16, perspective uint8) {
-	col := nnue.FeatureCols[feature]
-	acc := nnue.Acc.Values[perspective]
-	for o := 0; o < len(acc); o += 16 {
-		acc[o] -= col[o]
-		acc[o+1] -= col[o+1]
-		acc[o+2] -= col[o+2]
-		acc[o+3] -= col[o+3]
-		acc[o+4] -= col[o+4]
-		acc[o+5] -= col[o+5]
-		acc[o+6] -= col[o+6]
-		acc[o+7] -= col[o+7]
-		acc[o+8] -= col[o+8]
-		acc[o+9] -= col[o+9]
-		acc[o+10] -= col[o+10]
-		acc[o+11] -= col[o+11]
-		acc[o+12] -= col[o+12]
-		acc[o+13] -= col[o+13]
-		acc[o+14] -= col[o+14]
-		acc[o+15] -= col[o+15]
+// Remove incrementally removes a feature.
+func (acc *Accumulator) Remove(net *Network, feature uint16, perspective uint8) {
+	col := net.FeatureCols[feature]
+	a := acc.Values[perspective]
+	for o := 0; o < len(a); o += 16 {
+		a[o] -= col[o]
+		a[o+1] -= col[o+1]
+		a[o+2] -= col[o+2]
+		a[o+3] -= col[o+3]
+		a[o+4] -= col[o+4]
+		a[o+5] -= col[o+5]
+		a[o+6] -= col[o+6]
+		a[o+7] -= col[o+7]
+		a[o+8] -= col[o+8]
+		a[o+9] -= col[o+9]
+		a[o+10] -= col[o+10]
+		a[o+11] -= col[o+11]
+		a[o+12] -= col[o+12]
+		a[o+13] -= col[o+13]
+		a[o+14] -= col[o+14]
+		a[o+15] -= col[o+15]
 	}
 }
 
-func (nnue *NNUE) Evaluate(side uint8) float32 {
-	ourAcc := nnue.Acc.Values[side]
-	theirAcc := nnue.Acc.Values[1-side]
+func (acc *Accumulator) Evaluate(net *Network, side uint8) float32 {
+	ourAcc := acc.Values[side]
+	theirAcc := acc.Values[1-side]
 	var result float32 = 0.0
 
 	// ReLU before output layer
-	for i := 0; i < nnue.L1; i++ {
-		result += nnue.WOutput[i] * max(ourAcc[i], 0.0)
+	for i := 0; i < net.L1; i++ {
+		result += net.WOutput[i] * max(ourAcc[i], 0.0)
 	}
-	for j := 0; j < nnue.L1; j++ {
-		result += nnue.WOutput[nnue.L1+j] * max(theirAcc[j], 0.0)
+	for j := 0; j < net.L1; j++ {
+		result += net.WOutput[net.L1+j] * max(theirAcc[j], 0.0)
 	}
-	result += nnue.BOutput
+	result += net.BOutput
 	return result
 }

--- a/engine/nnue_loader.go
+++ b/engine/nnue_loader.go
@@ -1,71 +1,12 @@
 package engine
 
-import (
-	"embed"
-	"fmt"
-	"os"
-)
+import "embed"
 
 //go:embed nnue/*.nnue
 var nnueFS embed.FS
 
-// resolveNNUEPath returns a filesystem path to open for the NNUE data
-//
-// If `path` is empty: it writes the embedded default NNUE to a temp file and
-// returns that temp path and a cleanup func that should be deferred by caller
-//
-// If `path` is non-empty it is returned as-is (no cleanup function)
-//
-// error - failure if neither the provided filepath nor the embedded NNUE is available
-func resolveNNUEPath(path string) (string, func(), error) {
-	// caller provides path
-	if path != "" {
-		// caller is responsible for not deleting this file
-		return path, func() {}, nil
-	}
-	// embedded default
-	return writeEmbeddedToTemp("nnue/256.nnue")
-}
+const defaultNNUEName = "nnue/256.nnue"
 
-// write the embedded file `embeddedName` to a temporary
-// file and returns the temp path and a cleanup func that removes it
-func writeEmbeddedToTemp(embeddedName string) (string, func(), error) {
-	data, err := nnueFS.ReadFile(embeddedName)
-	if err != nil {
-		return "", nil, fmt.Errorf("embedded default nnue not found (%s): %w", embeddedName, err)
-	}
-
-	// tmp file at /tmp/nnue-xxxxxx.nnue
-	tmp, err := os.CreateTemp("", "nnue-*.nnue")
-	if err != nil {
-		return "", nil, err
-	}
-	// close tmp file at the end
-	tmpName := tmp.Name()
-	defer func() {
-		_ = tmp.Close()
-	}()
-
-	// write NNUE data to tmp file
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
-		return "", nil, err
-	}
-	// force data to disk
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpName)
-		return "", nil, err
-	}
-	// close tmp file
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName)
-		return "", nil, err
-	}
-	// cleanup function -- deleting tmp file
-	cleanup := func() {
-		_ = os.Remove(tmpName)
-	}
-	return tmpName, cleanup, nil
+func embeddedNNUEBytes() ([]byte, error) {
+	return nnueFS.ReadFile(defaultNNUEName)
 }

--- a/engine/nnue_test.go
+++ b/engine/nnue_test.go
@@ -1,47 +1,42 @@
 package engine_test
 
 import (
-	"fmt"
-	"silverfish/engine"
 	"testing"
+
+	"silverfish/engine"
 )
 
-// entirely manual verification against pytorch eval script for now
-// TODO: automatically run the torch eval script
-func TestRefreshEval(t *testing.T) {
+// The NNUE accumulator is updated incrementally (Add/Remove) on every
+// DoMove/UndoMove rather than recomputed from scratch. This test checks that
+// incremental updates stay consistent with a from-scratch build: after
+// playing a sequence of moves, the position's accumulator-derived evaluation
+// must match that of a fresh Position built straight from the resulting FEN
+// (which only ever calls Add, never Remove).
+func TestNNUEIncrementalMatchesFromScratch(t *testing.T) {
 	pos := engine.FromFEN("6k1/5p1p/1q2p1p1/1PnpP3/3N4/1Pr5/P5PP/3QR1K1 w - - 3 37")
 
-	// For 256_test.nnue (one nonzero weight)
-	//pos := engine.FromFEN("8/8/8/8/8/8/P7/8 w - - 0 1")
+	moves := []string{"d1a1", "b6a5", "d4c6"}
+	for _, m := range moves {
+		move := engine.NewMoveFromStr(m)
+		var legalMove engine.Move
+		found := false
+		for _, candidate := range pos.LegalMoves() {
+			if candidate.From() == move.From() && candidate.To() == move.To() {
+				legalMove, found = candidate, true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("move %s not found in legal moves", m)
+		}
+		pos.DoMove(legalMove)
+	}
 
-	// var featuresW []uint16
-	// var featuresB []uint16
-	// for sq := engine.SquareA1; sq <= engine.SquareH8; sq++ {
-	// 	if pos.Board[sq] >= 10 {
-	// 		featuresW = append(featuresW, engine.FeatureIndex(engine.White, engine.Black, pos.Board[sq]-uint8(10), sq))
-	// 		featuresB = append(featuresB, engine.FeatureIndex(engine.Black, engine.Black, pos.Board[sq]-uint8(10), sq))
-	// 	} else if pos.Board[sq] != 6 {
-	// 		featuresW = append(featuresW, engine.FeatureIndex(engine.White, engine.White, pos.Board[sq], sq))
-	// 		featuresB = append(featuresB, engine.FeatureIndex(engine.Black, engine.White, pos.Board[sq], sq))
-	// 	}
-	// }
-	fmt.Println(1000 * pos.Nnue.Evaluate(pos.Turn))
+	fresh := engine.FromFEN(pos.ToFEN())
 
-	pos.DoMove(engine.NewMoveFromStr("d1a1"))
-	// nnue.Remove(engine.FeatureIndex(engine.White, engine.White, engine.Queen, engine.SquareD1), engine.White)
-	// nnue.Remove(engine.FeatureIndex(engine.Black, engine.White, engine.Queen, engine.SquareD1), engine.Black)
-	// nnue.Add(engine.FeatureIndex(engine.White, engine.White, engine.Queen, engine.SquareA1), engine.White)
-	// nnue.Add(engine.FeatureIndex(engine.Black, engine.White, engine.Queen, engine.SquareA1), engine.Black)
-
-	fmt.Println(1000 * pos.Nnue.Evaluate(pos.Turn))
-
-	pos.DoMove(engine.NewMoveFromStr("b6a5"))
-	// nnue.Remove(engine.FeatureIndex(engine.White, engine.Black, engine.Queen, engine.SquareB6), engine.White)
-	// nnue.Remove(engine.FeatureIndex(engine.Black, engine.Black, engine.Queen, engine.SquareB6), engine.Black)
-	// nnue.Add(engine.FeatureIndex(engine.White, engine.Black, engine.Queen, engine.SquareA5), engine.White)
-	// nnue.Add(engine.FeatureIndex(engine.Black, engine.Black, engine.Queen, engine.SquareA5), engine.Black)
-
-	fmt.Println(1000 * pos.Nnue.Evaluate(pos.Turn))
-
-	// t.Errorf("")
+	got := engine.Evaluate(&pos)
+	want := engine.Evaluate(&fresh)
+	if got != want {
+		t.Errorf("incrementally updated eval = %d, from-scratch eval = %d; want equal", got, want)
+	}
 }

--- a/engine/perft_test.go
+++ b/engine/perft_test.go
@@ -1,0 +1,67 @@
+package engine_test
+
+import (
+	"testing"
+
+	"silverfish/engine"
+)
+
+// Node counts are the standard perft reference values (also used by
+// tools/run_perft.sh against known-good engines) for the startpos and the
+// Kiwipete/CPW test positions covering castling, en passant, promotion, and
+// discovered check.
+var perftCases = []struct {
+	name  string
+	fen   string
+	depth int
+	want  uint64
+}{
+	{"startpos", "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 4, 197281},
+	{"kiwipete", "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1", 3, 97862},
+	{"position 3", "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1", 5, 674624},
+	{"position 4", "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1", 3, 9467},
+	{"position 5", "rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8", 3, 62379},
+	{"position 6", "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", 3, 89890},
+}
+
+func TestPerft(t *testing.T) {
+	for _, tc := range perftCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pos := engine.FromFEN(tc.fen)
+			got := engine.Perft(&pos, tc.depth, false)
+			if got != tc.want {
+				t.Errorf("Perft(%q, %d) = %d, want %d", tc.fen, tc.depth, got, tc.want)
+			}
+		})
+	}
+}
+
+// Deeper perft runs are slow (kiwipete@4 alone takes several seconds); keep
+// them out of the default `go test` loop but available via -short=false.
+func TestPerftDeep(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping deep perft in -short mode")
+	}
+
+	cases := []struct {
+		name  string
+		fen   string
+		depth int
+		want  uint64
+	}{
+		{"startpos", "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 5, 4865609},
+		{"kiwipete", "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1", 4, 4085603},
+		{"position 4", "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1", 4, 422333},
+		{"position 6", "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", 4, 3894594},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pos := engine.FromFEN(tc.fen)
+			got := engine.Perft(&pos, tc.depth, false)
+			if got != tc.want {
+				t.Errorf("Perft(%q, %d) = %d, want %d", tc.fen, tc.depth, got, tc.want)
+			}
+		})
+	}
+}

--- a/engine/position.go
+++ b/engine/position.go
@@ -70,6 +70,17 @@ func StartingPosition() Position {
 	return FromFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
 }
 
+// Clone returns a deep copy. Position must not be copied by plain assignment
+// (`p2 := p1` / passing by value) -- Acc and History alias mutable state via
+// slices, so a plain copy shares them with the original. Net is the sole
+// exception: it's immutable, so sharing the pointer is safe.
+func (pos *Position) Clone() Position {
+	clone := *pos
+	clone.Acc = pos.Acc.Clone()
+	clone.History = append([]State(nil), pos.History...)
+	return clone
+}
+
 func (pos *Position) PutPiece(sq Square, piece uint8, color uint8) {
 	sqBB := Bitboard(1 << sq)
 	pos.Pieces[color][piece] |= sqBB

--- a/engine/position.go
+++ b/engine/position.go
@@ -45,7 +45,10 @@ type Position struct {
 	// past states
 	History []State
 
-	Nnue *NNUE
+	// Net is the immutable network shared across positions; Acc is this
+	// position's mutable per-perspective evaluation state.
+	Net *Network
+	Acc Accumulator
 }
 
 type State struct {
@@ -74,8 +77,8 @@ func (pos *Position) PutPiece(sq Square, piece uint8, color uint8) {
 	// nnue operations come before this adjustment by 10 (0-5 expected; FeatureIndex performs adjustment by 6)
 	fWhite := FeatureIndex(White, color, piece, sq)
 	fBlack := FeatureIndex(Black, color, piece, sq)
-	pos.Nnue.Add(fWhite, White)
-	pos.Nnue.Add(fBlack, Black)
+	pos.Acc.Add(pos.Net, fWhite, White)
+	pos.Acc.Add(pos.Net, fBlack, Black)
 
 	if color == Black {
 		piece += 10
@@ -88,8 +91,9 @@ func (pos *Position) PutPiece(sq Square, piece uint8, color uint8) {
 func (pos *Position) PutPiecesBB(pieces [2][6]Bitboard) {
 	// this check is for testing purposes only
 	// .. well this whole function is for testing purposes only
-	if pos.Nnue == nil {
-		pos.Nnue, _ = LoadNNUE("")
+	if pos.Net == nil {
+		pos.Net = defaultNet
+		pos.Acc = NewAccumulator(pos.Net)
 	}
 
 	for sq := SquareA1; sq <= SquareH8; sq++ {
@@ -121,8 +125,8 @@ func (pos *Position) RemovePiece(sq Square) {
 	// nnue operations come after this adjustment by 10 (0-5 expected; FeatureIndex performs adjustment by 6)
 	fWhite := FeatureIndex(White, color, piece, sq)
 	fBlack := FeatureIndex(Black, color, piece, sq)
-	pos.Nnue.Remove(fWhite, White)
-	pos.Nnue.Remove(fBlack, Black)
+	pos.Acc.Remove(pos.Net, fWhite, White)
+	pos.Acc.Remove(pos.Net, fBlack, Black)
 }
 
 func (pos *Position) Equals(otherPos Position) bool {
@@ -227,13 +231,13 @@ func (pos *Position) ToFEN() string {
 func FromFEN(fen string) Position {
 	var pos Position
 
-	var err error
-	pos.Nnue, err = LoadNNUE("")
-	if err != nil {
-		panic("error loading NNUE file")
+	if defaultNet == nil {
+		panic("engine.Init() must be called before engine.FromFEN()")
 	}
-	// empty refresh to add biases
-	pos.Nnue.RefreshAll([]uint16{}, []uint16{})
+	pos.Net = defaultNet
+	pos.Acc = NewAccumulator(pos.Net)
+	// install input bias before any Add/Remove
+	pos.Acc.Reset(pos.Net)
 
 	parts := strings.Split(fen, " ")
 	if len(parts) < 6 {

--- a/engine/position_test.go
+++ b/engine/position_test.go
@@ -446,3 +446,25 @@ func TestDoUndo(t *testing.T) {
 		fmt.Println("Got: " + pos.ToFEN())
 	}
 }
+
+// Clone must deep-copy the accumulator and history, not just alias them --
+// otherwise mutating the clone (via DoMove) corrupts the original.
+func TestCloneIsIndependent(t *testing.T) {
+	orig := engine.FromFEN("r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3")
+	origEval := engine.Evaluate(&orig)
+	origFEN := orig.ToFEN()
+	origHistoryLen := len(orig.History)
+
+	clone := orig.Clone()
+	clone.DoMove(engine.NewMoveFromStr("f1c4"))
+
+	if orig.ToFEN() != origFEN {
+		t.Errorf("cloning and mutating the clone changed the original position: before %q, after %q", origFEN, orig.ToFEN())
+	}
+	if got := engine.Evaluate(&orig); got != origEval {
+		t.Errorf("original eval changed after mutating the clone: before %d, after %d", origEval, got)
+	}
+	if len(orig.History) != origHistoryLen {
+		t.Errorf("original History grew after DoMove on the clone: before %d, after %d", origHistoryLen, len(orig.History))
+	}
+}

--- a/engine/search.go
+++ b/engine/search.go
@@ -9,6 +9,16 @@ const InfiniteMovetime = 600000 * time.Millisecond // arbitrary large number for
 const MaxMovetime = 2000                           // max movetime for any move if unspecified
 const MaxQuiescenceDepth = 8
 
+type Search struct {
+	Pos   Position
+	Nodes int
+
+	// limits
+	StartTime time.Time
+	TimeLimit time.Duration
+	MaxDepth  int
+}
+
 // return number in milliseconds
 func TimeLimit(pos *Position, command *UciGoMessage) time.Duration {
 	var ourTime, ourInc int32 //, theirTime, theirInc int32
@@ -73,17 +83,16 @@ func OrderMoves(pos *Position, moveList *MoveList) {
 // alpha: best score guaranteed for max-player. can prune branches that give less than this
 // beta: upper limit that min-player will tolerate. min-player will prune lines exceeding this
 
-// pass timeLimit in nanoseconds (default)
-func Search(pos *Position, maxDepth int, timeLimit time.Duration) (int32, Move) {
-	startTime := time.Now()
-
+// pass TimeLimit in nanoseconds (default)
+func (search *Search) Search() (int32, Move) {
 	var bestMove Move
 	bestScore := -Infinity
 
-	moveList := GenMoves(pos, BB_Full)
-	nodes := 0
+	search.StartTime = time.Now()
 
-	for depth := 1; depth <= maxDepth; depth++ {
+	moveList := GenMoves(&search.Pos, BB_Full)
+
+	for depth := 1; depth <= search.MaxDepth; depth++ {
 		alpha := -Infinity
 		beta := Infinity
 
@@ -92,15 +101,15 @@ func Search(pos *Position, maxDepth int, timeLimit time.Duration) (int32, Move) 
 
 		for i := uint8(0); i < moveList.Count; i++ {
 			move := moveList.Moves[i]
-			if !pos.MoveIsLegal(move) {
+			if !search.Pos.MoveIsLegal(move) {
 				continue
 			}
 
-			pos.DoMove(move)
-			score := -alphaBetaInner(pos, -beta, -alpha, depth-1, &nodes, &startTime, &timeLimit)
-			pos.UndoMove(move)
+			search.Pos.DoMove(move)
+			score := -search.alphaBetaInner(-beta, -alpha, depth-1)
+			search.Pos.UndoMove(move)
 
-			if time.Since(startTime) > timeLimit {
+			if time.Since(search.StartTime) > search.TimeLimit {
 				break
 			}
 
@@ -118,12 +127,12 @@ func Search(pos *Position, maxDepth int, timeLimit time.Duration) (int32, Move) 
 				hasDepth: true,
 				score:    bestScore,
 				hasScore: true,
-				nodes:    nodes,
+				nodes:    search.Nodes,
 				hasNodes: true,
 			})
 		}
 
-		if time.Since(startTime) > timeLimit {
+		if time.Since(search.StartTime) > search.TimeLimit {
 			break
 		}
 
@@ -134,12 +143,12 @@ func Search(pos *Position, maxDepth int, timeLimit time.Duration) (int32, Move) 
 	return bestScore, bestMove
 }
 
-func Quiescence(pos *Position, alpha, beta int32, nodes *int, startTime *time.Time, timeLimit *time.Duration, qdepth int) int32 {
+func (search *Search) Quiescence(alpha, beta int32, qdepth int) int32 {
 	if qdepth > MaxQuiescenceDepth {
-		return Evaluate(pos)
+		return Evaluate(&search.Pos)
 	}
 
-	standPat := Evaluate(pos)
+	standPat := Evaluate(&search.Pos)
 	if standPat >= beta {
 		return beta
 	}
@@ -148,26 +157,26 @@ func Quiescence(pos *Position, alpha, beta int32, nodes *int, startTime *time.Ti
 	}
 
 	var moveList MoveList
-	if pos.Checkers(pos.Turn) != 0 {
-		moveList = GenMoves(pos, BB_Full)
+	if search.Pos.Checkers(search.Pos.Turn) != 0 {
+		moveList = GenMoves(&search.Pos, BB_Full)
 	} else {
-		moveList = GenMoves(pos, pos.Sides[pos.Turn^1]) // only captures
+		moveList = GenMoves(&search.Pos, search.Pos.Sides[search.Pos.Turn^1]) // only captures
 	}
 
-	ScoreMoves(pos, &moveList)
-	OrderMoves(pos, &moveList)
+	ScoreMoves(&search.Pos, &moveList)
+	OrderMoves(&search.Pos, &moveList)
 
 	for i := uint8(0); i < moveList.Count; i++ {
 		move := moveList.Moves[i]
-		if !pos.MoveIsLegal(move) {
+		if !search.Pos.MoveIsLegal(move) {
 			continue
 		}
 
-		*nodes++
+		search.Nodes++
 
-		pos.DoMove(move)
-		score := -Quiescence(pos, -beta, -alpha, nodes, startTime, timeLimit, qdepth+1)
-		pos.UndoMove(move)
+		search.Pos.DoMove(move)
+		score := -search.Quiescence(-beta, -alpha, qdepth+1)
+		search.Pos.UndoMove(move)
 
 		if score >= beta {
 			return beta
@@ -180,15 +189,18 @@ func Quiescence(pos *Position, alpha, beta int32, nodes *int, startTime *time.Ti
 	return alpha
 }
 
-func alphaBetaInner(pos *Position, alpha, beta int32, depth int, nodes *int, startTime *time.Time, timeLimit *time.Duration) int32 {
-	moveList := GenMoves(pos, BB_Full)
-	ScoreMoves(pos, &moveList)
-	OrderMoves(pos, &moveList)
+func (search *Search) alphaBetaInner(alpha, beta int32, depth int) int32 {
+	search.Nodes++
+
+	moveList := GenMoves(&search.Pos, BB_Full)
+
+	ScoreMoves(&search.Pos, &moveList)
+	OrderMoves(&search.Pos, &moveList)
 
 	hasLegal := false
 
 	if moveList.Count == 0 {
-		if pos.Checkers(pos.Turn) != 0 {
+		if search.Pos.Checkers(search.Pos.Turn) != 0 {
 			// checkmate
 			return -Infinity
 		} else {
@@ -199,22 +211,20 @@ func alphaBetaInner(pos *Position, alpha, beta int32, depth int, nodes *int, sta
 
 	if depth == 0 {
 		// return Evaluate(pos)
-		return Quiescence(pos, alpha, beta, nodes, startTime, timeLimit, 0)
+		return search.Quiescence(alpha, beta, 0)
 	}
 
 	bestScore := -Infinity
 	for i := uint8(0); i < moveList.Count; i++ {
 		move := moveList.Moves[i]
-		if !pos.MoveIsLegal(move) {
+		if !search.Pos.MoveIsLegal(move) {
 			continue
 		}
 		hasLegal = true
 
-		*nodes++
-
-		pos.DoMove(move)
-		score := -alphaBetaInner(pos, -beta, -alpha, depth-1, nodes, startTime, timeLimit)
-		pos.UndoMove(move)
+		search.Pos.DoMove(move)
+		score := -search.alphaBetaInner(-beta, -alpha, depth-1)
+		search.Pos.UndoMove(move)
 
 		if score >= beta {
 			return score
@@ -226,11 +236,11 @@ func alphaBetaInner(pos *Position, alpha, beta int32, depth int, nodes *int, sta
 			alpha = score
 		}
 
-		if *nodes&32767 == 0 {
+		if search.Nodes&32767 == 0 {
 			UciInfo(UciInfoMessage{
 				depth:    depth,
 				hasDepth: true,
-				nodes:    *nodes,
+				nodes:    search.Nodes,
 				hasNodes: true,
 				score:    bestScore,
 				hasScore: true,
@@ -241,7 +251,7 @@ func alphaBetaInner(pos *Position, alpha, beta int32, depth int, nodes *int, sta
 	// GenMoves returns a list of valid but possibly illegal (leaves king in check) moves
 	// avoid the case where all moves are illegal (stalemate/checkmate) but moveList.Count != 0
 	if !hasLegal {
-		if pos.Checkers(pos.Turn) != 0 {
+		if search.Pos.Checkers(search.Pos.Turn) != 0 {
 			return -Infinity
 		} else {
 			return 0

--- a/engine/search.go
+++ b/engine/search.go
@@ -81,8 +81,6 @@ func OrderMoves(pos *Position, moveList *MoveList) {
 
 func (search *Search) Init(pos Position) {
 	search.Pos = pos
-	search.HistoryPly = 0
-	search.History[search.HistoryPly] = search.Pos.Hash
 }
 
 // based on negamax (flip sign), each player maximizes their own score

--- a/engine/search.go
+++ b/engine/search.go
@@ -79,8 +79,8 @@ func OrderMoves(pos *Position, moveList *MoveList) {
 	}
 }
 
-func (search *Search) Init(pos Position) {
-	search.Pos = pos
+func (search *Search) Init(pos *Position) {
+	search.Pos = pos.Clone()
 }
 
 // based on negamax (flip sign), each player maximizes their own score

--- a/engine/search.go
+++ b/engine/search.go
@@ -79,6 +79,12 @@ func OrderMoves(pos *Position, moveList *MoveList) {
 	}
 }
 
+func (search *Search) Init(pos Position) {
+	search.Pos = pos
+	search.HistoryPly = 0
+	search.History[search.HistoryPly] = search.Pos.Hash
+}
+
 // based on negamax (flip sign), each player maximizes their own score
 // alpha: best score guaranteed for max-player. can prune branches that give less than this
 // beta: upper limit that min-player will tolerate. min-player will prune lines exceeding this

--- a/engine/search_test.go
+++ b/engine/search_test.go
@@ -1,0 +1,92 @@
+package engine_test
+
+import (
+	"testing"
+	"time"
+
+	"silverfish/engine"
+)
+
+// Structural invariants that must hold regardless of how the evaluation is
+// tuned: the search returns a legal move, doesn't mutate the position it
+// started from, and explores at least one node.
+func TestSearchInvariants(t *testing.T) {
+	fen := "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"
+	pos := engine.FromFEN(fen)
+	before := pos.ToFEN()
+
+	search := engine.Search{
+		MaxDepth:  3,
+		TimeLimit: engine.InfiniteMovetime,
+	}
+	search.Init(pos)
+
+	_, bestMove := search.Search()
+
+	if bestMove == engine.Move(0) {
+		t.Fatalf("Search() returned a null move")
+	}
+	if !pos.MoveIsLegal(bestMove) {
+		t.Errorf("Search() returned illegal move %s", bestMove.ToString())
+	}
+	if pos.ToFEN() != before {
+		t.Errorf("Search() mutated the position: before %q, after %q", before, pos.ToFEN())
+	}
+	if search.Nodes == 0 {
+		t.Errorf("Search() explored 0 nodes")
+	}
+}
+
+// A fixed-depth search with no time pressure must be reproducible.
+func TestSearchReproducible(t *testing.T) {
+	fen := "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3"
+
+	run := func() (int32, engine.Move) {
+		pos := engine.FromFEN(fen)
+		search := engine.Search{
+			MaxDepth:  3,
+			TimeLimit: engine.InfiniteMovetime,
+		}
+		search.Init(pos)
+		return search.Search()
+	}
+
+	wantScore, wantMove := run()
+	for i := 0; i < 3; i++ {
+		gotScore, gotMove := run()
+		if gotScore != wantScore || gotMove != wantMove {
+			t.Errorf("run %d: got (%d, %s), want (%d, %s)", i, gotScore, gotMove.ToString(), wantScore, wantMove.ToString())
+		}
+	}
+}
+
+// Forced mates: any correct search must find them, independent of eval tuning.
+func TestSearchFindsMateInOne(t *testing.T) {
+	cases := []struct {
+		name string
+		fen  string
+	}{
+		{"back rank mate", "6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pos := engine.FromFEN(tc.fen)
+			search := engine.Search{
+				MaxDepth:  2,
+				TimeLimit: 4 * time.Second,
+			}
+			search.Init(pos)
+
+			score, bestMove := search.Search()
+			if score < engine.Infinity-10 {
+				t.Errorf("%s: score = %d, want a mate score near +Infinity", tc.name, score)
+			}
+
+			pos.DoMove(bestMove)
+			if len(pos.LegalMoves()) != 0 || pos.Checkers(pos.Turn) == 0 {
+				t.Errorf("%s: move %s is not checkmate", tc.name, bestMove.ToString())
+			}
+		})
+	}
+}

--- a/engine/search_test.go
+++ b/engine/search_test.go
@@ -19,7 +19,7 @@ func TestSearchInvariants(t *testing.T) {
 		MaxDepth:  3,
 		TimeLimit: engine.InfiniteMovetime,
 	}
-	search.Init(pos)
+	search.Init(&pos)
 
 	_, bestMove := search.Search()
 
@@ -47,7 +47,7 @@ func TestSearchReproducible(t *testing.T) {
 			MaxDepth:  3,
 			TimeLimit: engine.InfiniteMovetime,
 		}
-		search.Init(pos)
+		search.Init(&pos)
 		return search.Search()
 	}
 
@@ -76,7 +76,7 @@ func TestSearchFindsMateInOne(t *testing.T) {
 				MaxDepth:  2,
 				TimeLimit: 4 * time.Second,
 			}
-			search.Init(pos)
+			search.Init(&pos)
 
 			score, bestMove := search.Search()
 			if score < engine.Infinity-10 {

--- a/engine/search_test.go
+++ b/engine/search_test.go
@@ -90,3 +90,20 @@ func TestSearchFindsMateInOne(t *testing.T) {
 		})
 	}
 }
+
+// A free, undefended piece with no counterplay must be captured by any
+// correct search -- independent of eval tuning, since forfeiting it is a
+// clear material loss under any reasonable evaluation.
+func TestSearchCapturesHangingPiece(t *testing.T) {
+	pos := engine.FromFEN("4k3/8/8/7q/5N2/8/8/4K3 w - - 0 1")
+	search := engine.Search{
+		MaxDepth:  3,
+		TimeLimit: 4 * time.Second,
+	}
+	search.Init(&pos)
+
+	_, bestMove := search.Search()
+	if bestMove.To() != engine.SquareH5 {
+		t.Errorf("Search() = %s, want a move to h5 capturing the undefended queen", bestMove.ToString())
+	}
+}

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -7,43 +7,12 @@ import (
 	"strings"
 )
 
-const (
-	UciInitialState = iota
-	UciIdleState
-	UciActiveState
-	UciPingState
-	UciHaltState
-	UciSyncState
-)
-
 type UciGoMessage struct {
 	// When true, the engine should search infinitely
 	Infinite bool
 
 	// When true, the engine should perform perft
 	Perft bool
-
-	// A collection of moves to which the engine should restrict its
-	// consideration (in other words, the move reported with the bestmove
-	// message should be one of the moves in this collection),
-	SearchMoves []Move
-
-	// Remember - 0 indicates that it was not specified.
-	// Hopefully this doesn't bite us in the ass
-
-	// An indication that the engine should attempt to prove
-	// a mate in this many full moves (or twice this many plies) and may
-	// assume that it does not need to examine lines beyond this many full
-	// moves (or twice this many plies)
-	Mate int16
-
-	// Time limits (read spec for information. The one we are referencing
-	// has information about this on Page 14.)
-	WhiteTime          int16
-	BlackTime          int16
-	WhiteClockIncrease int16
-	BlackClockIncrease int16
-	MovesToGo          int16
 
 	// For traditional α/β engines, the maximum length in ply
 	// of the principal variation (before extensions and reductions have been
@@ -56,10 +25,6 @@ type UciGoMessage struct {
 	BTime int32
 	WInc  int32
 	BInc  int32
-
-	// For traditional engines, the maximum number of positions (counted with
-	// multiplicity) that the engine should examine,
-	Nodes int16
 }
 
 // I'm too lazy to copy and paste documentation for every single
@@ -86,34 +51,62 @@ const (
 	UciIsReadyClientMessage
 	UciQuitClientMessage
 	UciStopClientMessage
+	UciSetOptionClientMessage
 )
+
+// EvalFileDefaultLabel is the sentinel value UCI GUIs are expected to send
+// back (or that engines print as the `default`) to mean "use the network
+// built into the binary", matching the convention used by Stockfish's
+// EvalFile option.
+const EvalFileDefaultLabel = "<empty>"
+
+type UciSetOptionMessage struct {
+	Name  string
+	Value string
+}
+
+// uciProcessSetOptionMessage parses the remainder of a "setoption name <name>
+// [value <value>]" command (with "setoption " already trimmed). Splits on
+// the literal " value " rather than tokenizing on whitespace, since both the
+// option name and its value (e.g. a file path) may contain spaces.
+func uciProcessSetOptionMessage(message string) UciSetOptionMessage {
+	message = strings.TrimPrefix(message, "name ")
+
+	if idx := strings.Index(message, " value "); idx != -1 {
+		return UciSetOptionMessage{
+			Name:  strings.TrimSpace(message[:idx]),
+			Value: message[idx+len(" value "):],
+		}
+	}
+	return UciSetOptionMessage{Name: strings.TrimSpace(message)}
+}
 
 type UciClientMessage struct {
 	Position    *Position
 	GoMessage   *UciGoMessage
+	SetOption   *UciSetOptionMessage
 	MessageType uint8
-}
-
-var UciState = UciInitialState
-
-type UciErrorType struct {
-	err string
-}
-
-func NewUciError(err string) *UciErrorType {
-	return &UciErrorType{
-		err: err,
-	}
-}
-
-func (err *UciErrorType) Error() string {
-	return err.err
 }
 
 func uciProcessGoMessage(message string) UciGoMessage {
 	result := UciGoMessage{}
 
 	tokens := strings.Split(message, " ")
+
+	// intArg returns the integer following tokens[i], or ok=false if it's
+	// missing (i is the last token) or not a valid integer.
+	intArg := func(i int) (int, bool) {
+		if i+1 >= len(tokens) {
+			UciError(fmt.Sprintf("missing argument for %q", tokens[i]))
+			return 0, false
+		}
+		value, err := strconv.Atoi(tokens[i+1])
+		if err != nil {
+			UciError(fmt.Sprintf("invalid argument for %q: %q", tokens[i], tokens[i+1]))
+			return 0, false
+		}
+		return value, true
+	}
 
 	for i, token := range tokens {
 		switch token {
@@ -122,43 +115,30 @@ func uciProcessGoMessage(message string) UciGoMessage {
 		case "perft":
 			result.Perft = true
 		case "depth":
-			depth, err := strconv.Atoi(tokens[i+1])
-			if err != nil {
-				UciError("something unknown")
+			if depth, ok := intArg(i); ok {
+				result.Depth = int16(depth)
 			}
-			result.Depth = int16(depth)
 		case "movetime":
-			movetime, err := strconv.Atoi(tokens[i+1])
-			if err != nil {
-				UciError("something unknown")
+			if movetime, ok := intArg(i); ok {
+				result.Movetime = int32(movetime)
 			}
-			result.Movetime = int32(movetime)
 		case "wtime":
-			wtime, err := strconv.Atoi(tokens[i+1])
-			if err != nil {
-				UciError("something unknown")
+			if wtime, ok := intArg(i); ok {
+				result.WTime = int32(wtime)
 			}
-			result.WTime = int32(wtime)
 		case "btime":
-			btime, err := strconv.Atoi(tokens[i+1])
-			if err != nil {
-				UciError("something unknown")
+			if btime, ok := intArg(i); ok {
+				result.BTime = int32(btime)
 			}
-			result.BTime = int32(btime)
 		case "winc":
-			winc, err := strconv.Atoi(tokens[i+1])
-			if err != nil {
-				UciError("something unknown")
+			if winc, ok := intArg(i); ok {
+				result.WInc = int32(winc)
 			}
-			result.WInc = int32(winc)
 		case "binc":
-			binc, err := strconv.Atoi(tokens[i+1])
-			if err != nil {
-				UciError("something unknown")
+			if binc, ok := intArg(i); ok {
+				result.BInc = int32(binc)
 			}
-			result.BInc = int32(binc)
 		}
-
 	}
 
 	return result
@@ -227,6 +207,11 @@ func UciProcessClientMessage(stdin *bufio.Scanner) UciClientMessage {
 	} else if textMessage == "stop" {
 		message.MessageType = UciStopClientMessage
 		return message
+	} else if strings.HasPrefix(textMessage, "setoption") {
+		opt := uciProcessSetOptionMessage(strings.TrimPrefix(textMessage, "setoption "))
+		message.SetOption = &opt
+		message.MessageType = UciSetOptionClientMessage
+		return message
 	}
 
 	// Just return the empty message at this point
@@ -291,8 +276,8 @@ func UciSetEngineName(name string) {
 	fmt.Printf("id name %s\n", name)
 }
 
-// Normally, one should just use protocol 2, as that is the protocol that I am
-// implementing.
-func UciSetProtocol(protocol uint8) {
-	fmt.Printf("protocol %d\n", protocol)
+// UciOptions prints the engine's supported `option` lines. Should be sent
+// after `id`/before `uciok`, per the UCI spec.
+func UciOptions() {
+	fmt.Printf("option name EvalFile type string default %s\n", EvalFileDefaultLabel)
 }


### PR DESCRIPTION
Structural refactor pass, no intended change in playing strength. Split from the zobrist-threefold branch so this can land independently.

- Replaced disabled/print-only tests in evaluation and search with real assertions (side-to-move symmetry, incremental-vs-fresh NNUE consistency, search invariants, mate-in-1, forced capture). go test ./engine was previously red.
- Added perft as a real go test using standard reference positions, gated behind -short for the slow cases.
- NNUE loading: read from an io.Reader instead of writing the embedded net to a temp file every load. Split NNUE into an immutable Network (loaded once in engine.Init) and a per-position Accumulator, instead of reloading and reparsing the ~800KB net on every FromFEN call. FromFEN went from about 1.6ms to about 7us.
- Added Position.Clone() and removed unsafe by-value copies of Position, which previously shared the NNUE accumulator and move history across copies.
- UCI: fixed the main loop busy-waiting at 100% CPU while idle, fixed a dead active flag that let concurrent searches race on the same position, added a setoption EvalFile option for picking an NNUE net at runtime, bounds-checked go command argument parsing, and deleted unused code (state machine, error type, duplicate message fields).

Verified with go build, go vet, full test suite, and manual UCI smoke tests. Also ran perft before/after on the real binary to confirm no speed regression in move generation.