### PR TITLE
Fix alpha-beta timeout handling, quiescence mate detection, and UCI progress info

### DIFF
--- a/engine/search.go
+++ b/engine/search.go
@@ -150,21 +150,32 @@ func (search *Search) Search() (int32, Move) {
 	return bestScore, bestMove
 }
 
-func (search *Search) Quiescence(alpha, beta int32, qdepth int) int32 {
+// ply mirrors alphaBetaInner's ply: the number of plies from the search
+// root, needed so a checkmate found here scores consistently with one found
+// in alphaBetaInner (see the mate-distance comment there).
+func (search *Search) Quiescence(alpha, beta int32, qdepth int, ply int) int32 {
 	if qdepth > MaxQuiescenceDepth {
 		return Evaluate(&search.Pos)
 	}
 
-	standPat := Evaluate(&search.Pos)
-	if standPat >= beta {
-		return beta
-	}
-	if standPat > alpha {
-		alpha = standPat
+	inCheck := search.Pos.Checkers(search.Pos.Turn) != 0
+
+	// Unlike a capture, check can't be declined -- taking a stand-pat floor
+	// while in check can hide that the position is actually lost (or won)
+	// tactically, so it's skipped entirely here; every evasion must be
+	// searched instead.
+	if !inCheck {
+		standPat := Evaluate(&search.Pos)
+		if standPat >= beta {
+			return beta
+		}
+		if standPat > alpha {
+			alpha = standPat
+		}
 	}
 
 	var moveList MoveList
-	if search.Pos.Checkers(search.Pos.Turn) != 0 {
+	if inCheck {
 		moveList = GenMoves(&search.Pos, BB_Full)
 	} else {
 		moveList = GenMoves(&search.Pos, search.Pos.Sides[search.Pos.Turn^1]) // only captures
@@ -173,16 +184,18 @@ func (search *Search) Quiescence(alpha, beta int32, qdepth int) int32 {
 	ScoreMoves(&search.Pos, &moveList)
 	OrderMoves(&search.Pos, &moveList)
 
+	hasLegal := false
 	for i := uint8(0); i < moveList.Count; i++ {
 		move := moveList.Moves[i]
 		if !search.Pos.MoveIsLegal(move) {
 			continue
 		}
+		hasLegal = true
 
 		search.Nodes++
 
 		search.Pos.DoMove(move)
-		score := -search.Quiescence(-beta, -alpha, qdepth+1)
+		score := -search.Quiescence(-beta, -alpha, qdepth+1, ply+1)
 		search.Pos.UndoMove(move)
 
 		if score >= beta {
@@ -191,6 +204,12 @@ func (search *Search) Quiescence(alpha, beta int32, qdepth int) int32 {
 		if score > alpha {
 			alpha = score
 		}
+	}
+
+	// Running out of captures just means "stand pat" (handled above), but
+	// running out of legal evasions while in check is checkmate.
+	if inCheck && !hasLegal {
+		return -(Infinity - int32(ply))
 	}
 
 	return alpha
@@ -222,7 +241,7 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 
 	if depth == 0 {
 		// return Evaluate(pos)
-		return search.Quiescence(alpha, beta, 0)
+		return search.Quiescence(alpha, beta, 0, ply)
 	}
 
 	bestScore := -Infinity

--- a/engine/search.go
+++ b/engine/search.go
@@ -9,6 +9,31 @@ const InfiniteMovetime = 600000 * time.Millisecond // arbitrary large number for
 const MaxMovetime = 2000                           // max movetime for any move if unspecified
 const MaxQuiescenceDepth = 8
 
+// MateScoreThreshold: any score at least this close to Infinity is a mate
+// score (see the mate-distance comment on alphaBetaInner), not a real
+// evaluation -- real evaluations never get remotely close to Infinity.
+const MateScoreThreshold = Infinity - 10000
+
+// mateInfo reports whether score is a forced-mate score and, if so, converts
+// it to UCI's "score mate N" convention: N is moves (not plies) to mate,
+// positive if the engine's side delivers it and negative if it's being
+// mated.
+func mateInfo(score int32) (movesToMate int32, isMate bool) {
+	abs := score
+	if abs < 0 {
+		abs = -abs
+	}
+	if abs < MateScoreThreshold {
+		return 0, false
+	}
+	pliesToMate := Infinity - abs
+	movesToMate = (pliesToMate + 1) / 2
+	if score < 0 {
+		movesToMate = -movesToMate
+	}
+	return movesToMate, true
+}
+
 type Search struct {
 	Pos   Position
 	Nodes int
@@ -107,6 +132,7 @@ func (search *Search) Search() (int32, Move) {
 
 		bestScoreCurr := -Infinity
 		var bestMoveCurr Move
+		timedOut := false
 
 		for i := uint8(0); i < moveList.Count; i++ {
 			move := moveList.Moves[i]
@@ -118,10 +144,6 @@ func (search *Search) Search() (int32, Move) {
 			score := -search.alphaBetaInner(-beta, -alpha, depth-1, 1)
 			search.Pos.UndoMove(move)
 
-			if time.Since(search.StartTime) > search.TimeLimit {
-				break
-			}
-
 			// ensure a null move is not chosen (in case of unavoidable checkmate)
 			if score > bestScoreCurr || bestMoveCurr == Move(0) {
 				bestScoreCurr = score
@@ -131,22 +153,50 @@ func (search *Search) Search() (int32, Move) {
 				alpha = score
 			}
 
-			UciInfo(UciInfoMessage{
-				depth:    depth,
-				hasDepth: true,
-				score:    bestScore,
-				hasScore: true,
-				nodes:    search.Nodes,
-				hasNodes: true,
-			})
+			if time.Since(search.StartTime) > search.TimeLimit {
+				timedOut = true
+				break
+			}
 		}
 
-		if time.Since(search.StartTime) > search.TimeLimit {
+		// A depth that fully explored every root move is strictly better
+		// information than any previous (shallower) depth, so always trust
+		// it. A depth that timed out partway through only checked some
+		// prefix of the (move-ordered, but not perfectly) root list -- if we
+		// already have a complete result from a previous depth, that result
+		// is more reliable than this partial one and must NOT be
+		// overwritten. The only time a partial result is used is when there
+		// is nothing else yet at all (typically depth 1 timing out before
+		// its first move even finishes) -- a partial answer beats returning
+		// an illegal null move.
+		if !timedOut || bestMove == Move(0) {
+			if bestMoveCurr != Move(0) {
+				bestScore = bestScoreCurr
+				bestMove = bestMoveCurr
+
+				// Reported once per completed depth, with that depth's own
+				// final score -- not per move, and not a stale score left
+				// over from the previous depth.
+				infoScore := bestScore
+				movesToMate, isMate := mateInfo(bestScore)
+				if isMate {
+					infoScore = movesToMate
+				}
+				UciInfo(UciInfoMessage{
+					depth:    depth,
+					hasDepth: true,
+					score:    infoScore,
+					hasScore: true,
+					isMate:   isMate,
+					nodes:    search.Nodes,
+					hasNodes: true,
+				})
+			}
+		}
+
+		if timedOut {
 			break
 		}
-
-		bestScore = bestScoreCurr
-		bestMove = bestMoveCurr
 	}
 
 	return bestScore, bestMove
@@ -269,13 +319,16 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 		}
 
 		if search.Nodes&32767 == 0 {
+			// No score here: bestScore is this internal node's own
+			// negamax-local value, not the root-relative evaluation UCI's
+			// `score` field is supposed to report -- nodes/depth are the
+			// only legitimate "still working" signal available this deep in
+			// the tree.
 			UciInfo(UciInfoMessage{
 				depth:    depth,
 				hasDepth: true,
 				nodes:    search.Nodes,
 				hasNodes: true,
-				score:    bestScore,
-				hasScore: true,
 			})
 		}
 	}

--- a/engine/search.go
+++ b/engine/search.go
@@ -98,6 +98,8 @@ func (search *Search) Search() (int32, Move) {
 	search.StartTime = time.Now()
 
 	moveList := GenMoves(&search.Pos, BB_Full)
+	ScoreMoves(&search.Pos, &moveList)
+	OrderMoves(&search.Pos, &moveList)
 
 	for depth := 1; depth <= search.MaxDepth; depth++ {
 		alpha := -Infinity

--- a/engine/search_test.go
+++ b/engine/search_test.go
@@ -1,11 +1,67 @@
 package engine_test
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"silverfish/engine"
 )
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it -- UciInfo prints directly to stdout, so this is
+// the only way to observe the search-progress messages it emits.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+
+	fn()
+
+	os.Stdout = old
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+// parseUciInfoLine extracts the fields TestUciInfo* care about from one
+// "info ..." line. hasScore is false for the internal periodic ping, which
+// deliberately omits the score field.
+func parseUciInfoLine(line string) (depth int, score int32, isMate bool, hasScore bool) {
+	fields := strings.Fields(line)
+	for i, f := range fields {
+		switch f {
+		case "depth":
+			if i+1 < len(fields) {
+				d, _ := strconv.Atoi(fields[i+1])
+				depth = d
+			}
+		case "cp":
+			if i+1 < len(fields) {
+				v, _ := strconv.Atoi(fields[i+1])
+				score = int32(v)
+				hasScore = true
+			}
+		case "mate":
+			if i+1 < len(fields) {
+				v, _ := strconv.Atoi(fields[i+1])
+				score = int32(v)
+				hasScore = true
+				isMate = true
+			}
+		}
+	}
+	return
+}
 
 // Structural invariants that must hold regardless of how the evaluation is
 // tuned: the search returns a legal move, doesn't mutate the position it
@@ -34,6 +90,97 @@ func TestSearchInvariants(t *testing.T) {
 	}
 	if search.Nodes == 0 {
 		t.Errorf("Search() explored 0 nodes")
+	}
+}
+
+// Even under a time budget so tight it expires mid-way through the very
+// first iterative-deepening iteration, Search() must still return a legal
+// move -- never the zero-value null move, which would be sent straight to
+// the GUI as an illegal "bestmove".
+func TestSearchTightTimeLimitReturnsLegalMove(t *testing.T) {
+	fen := "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"
+	pos := engine.FromFEN(fen)
+
+	search := engine.Search{
+		MaxDepth:  engine.InfiniteDepth,
+		TimeLimit: 0,
+	}
+	search.Init(&pos)
+
+	_, bestMove := search.Search()
+
+	if bestMove == engine.Move(0) {
+		t.Fatalf("Search() returned a null move under a zero time limit")
+	}
+	if !pos.MoveIsLegal(bestMove) {
+		t.Errorf("Search() returned illegal move %s", bestMove.ToString())
+	}
+}
+
+// A deeper iterative-deepening depth that only partway completes (checked
+// some but not all root moves before the clock ran out) must NOT overwrite
+// a shallower depth that fully completed -- the complete result is strictly
+// more reliable than an incomplete deeper one that may not have reached the
+// true best move yet. Regression test for a real bug: an earlier version of
+// the timeout fix committed any partial progress unconditionally, which at
+// real time controls (where the deepest attempted iteration almost always
+// times out mid-way) made the engine routinely discard a solid, fully-
+// searched shallow result in favor of whatever the first couple of moves at
+// the next depth happened to be -- caught by an SPRT run scoring 0-97 against
+// the pre-fix engine.
+func TestSearchTimeoutKeepsLastFullyCompletedDepth(t *testing.T) {
+	fen := "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"
+
+	runToCompletion := func(maxDepth int) (int32, engine.Move, time.Duration) {
+		pos := engine.FromFEN(fen)
+		search := engine.Search{MaxDepth: maxDepth, TimeLimit: engine.InfiniteMovetime}
+		search.Init(&pos)
+		start := time.Now()
+		score, move := search.Search()
+		return score, move, time.Since(start)
+	}
+
+	wantScore, wantMove, elapsed2 := runToCompletion(2)
+	_, _, elapsed3 := runToCompletion(3)
+
+	if elapsed3 <= elapsed2 {
+		t.Skip("depth 3 didn't take meaningfully longer than depth 2 on this machine; can't construct a reliable partial-depth timeout")
+	}
+	// Comfortably past depth 2's own completion time, but well short of
+	// depth 3's -- gives the timed run room to start depth 3, check a few
+	// moves, and time out mid-way.
+	budget := elapsed2 + (elapsed3-elapsed2)/3
+
+	pos := engine.FromFEN(fen)
+	search := engine.Search{MaxDepth: 8, TimeLimit: budget}
+	search.Init(&pos)
+	gotScore, gotMove := search.Search()
+
+	if gotMove != wantMove || gotScore != wantScore {
+		t.Errorf("timed search (budget %s, between depth-2 %s and depth-3 %s) = (%d, %s), want the fully-completed depth-2 result (%d, %s)",
+			budget, elapsed2, elapsed3, gotScore, gotMove.ToString(), wantScore, wantMove.ToString())
+	}
+}
+
+// Documents (rather than "fixes") the one case where Search() has no legal
+// move to give: a root position that's already checkmate. There's nothing
+// to return here, so this pins down the current, well-defined behavior
+// (null move, -Infinity score) so it doesn't change by accident.
+func TestSearchTerminalRootPositionReturnsNullMove(t *testing.T) {
+	pos := engine.FromFEN("R5k1/5ppp/8/8/8/8/8/6K1 b - - 1 1")
+	search := engine.Search{
+		MaxDepth:  3,
+		TimeLimit: engine.InfiniteMovetime,
+	}
+	search.Init(&pos)
+
+	score, bestMove := search.Search()
+
+	if bestMove != engine.Move(0) {
+		t.Errorf("Search() on a checkmated root = %s, want the null move (no legal move exists)", bestMove.ToString())
+	}
+	if score != -engine.Infinity {
+		t.Errorf("Search() on a checkmated root score = %d, want -Infinity", score)
 	}
 }
 
@@ -184,5 +331,98 @@ func TestSearchCapturesHangingPiece(t *testing.T) {
 	_, bestMove := search.Search()
 	if bestMove.To() != engine.SquareH5 {
 		t.Errorf("Search() = %s, want a move to h5 capturing the undefended queen", bestMove.ToString())
+	}
+}
+
+// UciInfo's search-progress messages must report each completed depth's
+// real score exactly once -- not repeated per root move with a stale value
+// left over from the previous depth (the root-loop bug), and the periodic
+// internal-node progress ping must never carry a score field (that value is
+// a local negamax number from deep in the tree, not the root-relative score
+// UCI's `score` field is supposed to report).
+func TestUciInfoReportsScoreOncePerDepth(t *testing.T) {
+	fen := "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"
+	pos := engine.FromFEN(fen)
+	search := engine.Search{MaxDepth: 4, TimeLimit: engine.InfiniteMovetime}
+	search.Init(&pos)
+
+	var finalScore int32
+	output := captureStdout(t, func() {
+		finalScore, _ = search.Search()
+	})
+
+	seenAtDepth := map[int]int{}
+	sawUnscoredPing := false
+	var lastScore int32
+	var lastDepth int
+
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "info") {
+			continue
+		}
+		depth, score, isMate, hasScore := parseUciInfoLine(line)
+		if !hasScore {
+			sawUnscoredPing = true
+			continue
+		}
+		if isMate {
+			t.Fatalf("unexpected mate score in a non-mate position: %q", line)
+		}
+		seenAtDepth[depth]++
+		lastScore = score
+		lastDepth = depth
+	}
+
+	for d, count := range seenAtDepth {
+		if count != 1 {
+			t.Errorf("depth %d: got %d scored info lines, want exactly 1", d, count)
+		}
+	}
+	if lastDepth != 4 {
+		t.Errorf("last scored info line was depth %d, want 4 (MaxDepth)", lastDepth)
+	}
+	if lastScore != finalScore {
+		t.Errorf("last scored info line score = %d, want %d (Search()'s returned score)", lastScore, finalScore)
+	}
+	if !sawUnscoredPing {
+		t.Errorf("expected at least one unscored internal-node progress ping (search.Nodes should exceed 32767 at this depth)")
+	}
+}
+
+// A mate score must be reported as UCI's "score mate N" (moves to mate),
+// not "score cp <huge centipawn number>".
+func TestUciInfoReportsMateFormat(t *testing.T) {
+	pos := engine.FromFEN("6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 1")
+	search := engine.Search{MaxDepth: 2, TimeLimit: 4 * time.Second}
+	search.Init(&pos)
+
+	output := captureStdout(t, func() {
+		search.Search()
+	})
+
+	var lastIsMate bool
+	var lastMateValue int32
+	var sawScoredLine bool
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "info") {
+			continue
+		}
+		_, score, isMate, hasScore := parseUciInfoLine(line)
+		if !hasScore {
+			continue
+		}
+		sawScoredLine = true
+		lastIsMate = isMate
+		lastMateValue = score
+	}
+
+	if !sawScoredLine {
+		t.Fatalf("no scored info line found in output:\n%s", output)
+	}
+	if !lastIsMate {
+		t.Errorf("mate-in-1 position: last scored info line used score cp, want score mate")
+	}
+	if lastMateValue != 1 {
+		t.Errorf("score mate %d, want score mate 1", lastMateValue)
 	}
 }

--- a/engine/search_test.go
+++ b/engine/search_test.go
@@ -60,6 +60,31 @@ func TestSearchReproducible(t *testing.T) {
 	}
 }
 
+// Quiescence must recognize checkmate reached via a capture, not silently
+// fall back to a stand-pat-derived evaluation. MaxDepth=1 means the position
+// right after White's move is evaluated by Quiescence itself (depth 0), so
+// this specifically exercises Quiescence's own mate detection, not
+// alphaBetaInner's. g1g7 (Qxg7#) is a real forced mate: the queen captures
+// the only black pawn with check, defended by the bishop on h6, and the
+// black king has no flight square or recapture -- verified with
+// tools/chess_check.py rather than by hand.
+func TestQuiescenceDetectsCheckmate(t *testing.T) {
+	pos := engine.FromFEN("7k/6p1/7B/8/8/8/8/4K1Q1 w - - 0 1")
+	search := engine.Search{
+		MaxDepth:  1,
+		TimeLimit: 4 * time.Second,
+	}
+	search.Init(&pos)
+
+	score, bestMove := search.Search()
+	if score < engine.Infinity-10 {
+		t.Errorf("score = %d, want a mate score near +Infinity", score)
+	}
+	if bestMove.ToString() != "g1g7" {
+		t.Errorf("bestMove = %s, want g1g7 (Qxg7#)", bestMove.ToString())
+	}
+}
+
 // Forced mates: any correct search must find them, independent of eval tuning.
 func TestSearchFindsMateInOne(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
```
Results of post vs pre (15+0.15, NULL, NULL, 8moves_v3.pgn):
Elo: 29.34 +/- 17.98, nElo: 41.19 +/- 25.10
LOS: 99.94 %, DrawRatio: 36.14 %, PairsRatio: 1.55
Games: 736, Wins: 227, Losses: 165, Draws: 344, Points: 399.0 (54.21 %)
Ptnml(0-2): [19, 73, 133, 113, 30], WL/DD Ratio: 0.68
LLR: 3.01 (102.3%) (-2.94, 2.94) [0.00, 15.00]
--------------------------------------------------
SPRT ([0.00, 15.00]) completed - H1 was accepted
Finished match
Total Time: 00:18:20 (hours:minutes:seconds)
```

- Quiescence took a stand-pat evaluation even while in check and never checked whether any legal evasion existed, so running into checkmate partway through a capture sequence silently returned a quiet-looking eval instead of a mate score. Fixed to skip stand-pat while in check and detect checkmate the same way alphaBetaInner does, with mate-distance scoring threaded through consistently.
- Root moves were never scored/ordered before searching, unlike every internal node. Added MVV-LVA ordering at the root too. Verified with ordering on vs off at a fixed depth: identical scores/best-moves either way (as alpha-beta correctness guarantees), fewer or equal nodes with ordering on.
- Root-loop timeout handling discarded a fully-evaluated move's score if the clock expired right after, and could return the zero-value null move as "bestmove" under real time pressure. Fixed to record each move's result before checking the clock, and to only use a timed-out depth's partial progress when there's nothing else yet, rather than overwriting a fully-searched shallower depth with an incomplete deeper one.
- UCI progress info reported a stale score from the previous depth on every root move (instead of once per completed depth with the right score), sent a meaningless local value from internal nodes, and never formatted mate scores as `score mate N`. All three fixed.

Each fix has a dedicated regression test (quiescence-mate detection, root-timeout/null-move, a real bug caught mid-SPRT where partial-depth progress was overwriting a reliable shallower result, and UCI info correctness via stdout capture). Full `go test ./engine` (including perft) passes throughout.