### PR TITLE
Add Zobrist hashing and in-search repetition detection

### DIFF
--- a/engine/domove_bench_test.go
+++ b/engine/domove_bench_test.go
@@ -1,0 +1,30 @@
+package engine_test
+
+import (
+	"testing"
+
+	"silverfish/engine"
+)
+
+// Isolates DoMove/UndoMove cost specifically (as opposed to perft, which
+// also spends time in move generation) -- useful for measuring the direct
+// overhead of anything added to the make/unmake path, like incremental
+// Zobrist hashing.
+func BenchmarkDoUndoMove(b *testing.B) {
+	pos := engine.FromFEN("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1")
+	moveList := engine.GenMoves(&pos, engine.BB_Full)
+	var moves []engine.Move
+	for i := uint8(0); i < moveList.Count; i++ {
+		m := moveList.Moves[i]
+		if pos.MoveIsLegal(m) {
+			moves = append(moves, m)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m := moves[i%len(moves)]
+		pos.DoMove(m)
+		pos.UndoMove(m)
+	}
+}

--- a/engine/init.go
+++ b/engine/init.go
@@ -10,6 +10,7 @@ var defaultNet *Network
 
 func Init() {
 	InitBitboard()
+	InitZobrist()
 	if err := LoadDefaultNetwork(""); err != nil {
 		panic("engine: failed to load default NNUE network: " + err.Error())
 	}

--- a/engine/position.go
+++ b/engine/position.go
@@ -670,3 +670,30 @@ func (pos *Position) Checkers(color uint8) Bitboard {
 	kingSq := Lsb(kingBB)
 	return pos.AttackersFrom(kingSq, color^1)
 }
+
+// IsRepetition reports whether the current position has occurred before,
+// earlier in this same game (History covers the whole game, not just the
+// current search: main.go replays every move from the UCI "position"
+// command before searching). Treats the first repetition as a draw rather
+// than waiting for a literal threefold -- standard practice, since if a
+// position can be repeated once under continued play, it can be forced
+// again, and there's no benefit to spending nodes proving that a second
+// time.
+//
+// Only positions with the same side to move can repeat, so this steps back
+// two plies at a time. The scan is bounded by Rule50: a capture or pawn
+// move is irreversible, so nothing before the most recent one can be equal
+// to the current position.
+func (pos *Position) IsRepetition() bool {
+	n := len(pos.History)
+	limit := int(pos.Rule50)
+	if limit > n {
+		limit = n
+	}
+	for i := 2; i <= limit; i += 2 {
+		if pos.History[n-i].Hash == pos.Hash {
+			return true
+		}
+	}
+	return false
+}

--- a/engine/position.go
+++ b/engine/position.go
@@ -49,6 +49,11 @@ type Position struct {
 	// position's mutable per-perspective evaluation state.
 	Net *Network
 	Acc Accumulator
+
+	// Hash is this position's Zobrist key, maintained incrementally by
+	// PutPiece/RemovePiece and DoMove/UndoMove. Used for repetition
+	// detection (IsRepetition).
+	Hash uint64
 }
 
 type State struct {
@@ -57,6 +62,7 @@ type State struct {
 	Rule50          uint8
 	CapturedPiece   uint8
 	MovedPiece      uint8
+	Hash            uint64
 }
 
 const (
@@ -97,6 +103,8 @@ func (pos *Position) PutPiece(sq Square, piece uint8, color uint8) {
 	pos.Board[sq] = piece
 	pos.Blockers |= sqBB
 	pos.Sides[color] |= sqBB
+
+	pos.Hash ^= pieceSqKey(sq, piece)
 }
 
 func (pos *Position) PutPiecesBB(pieces [2][6]Bitboard) {
@@ -125,7 +133,8 @@ func (pos *Position) PutPiecesBB(pieces [2][6]Bitboard) {
 }
 
 func (pos *Position) RemovePiece(sq Square) {
-	piece := pos.Board[sq]
+	boardPiece := pos.Board[sq] // pre-adjustment (0-5 white, 10-15 black), for the hash key
+	piece := boardPiece
 	color := ColorOf(piece)
 	if color == Black {
 		piece -= 10
@@ -137,6 +146,8 @@ func (pos *Position) RemovePiece(sq Square) {
 	if color != NoColor {
 		pos.Pieces[color][piece] &^= sqBB
 	}
+
+	pos.Hash ^= pieceSqKey(sq, boardPiece)
 
 	// nnue operations come after this adjustment by 10 (0-5 expected; FeatureIndex performs adjustment by 6)
 	fWhite := FeatureIndex(White, color, piece, sq)
@@ -348,6 +359,7 @@ func FromFEN(fen string) Position {
 		panic("invalid fullmove field")
 	}
 	pos.Ply = uint16((fullmove-1)*2 + int(pos.Turn))
+	pos.Hash = Hash(&pos)
 
 	return pos
 }
@@ -371,11 +383,13 @@ func (pos *Position) DoMove(move Move) {
 		CastlingRights:  pos.CastlingRights,
 		Rule50:          pos.Rule50,
 		EnPassantSquare: pos.EnPassantSquare,
+		Hash:            pos.Hash,
 	}
 
 	pos.Rule50++
 
 	// update en passant square
+	pos.Hash ^= enPassantKey(pos.EnPassantSquare)
 	if movingPiece == Pawn {
 		dist := int(to) - int(from)
 		pawnDisplacement := PawnDisplacement(ourColor)
@@ -388,8 +402,10 @@ func (pos *Position) DoMove(move Move) {
 	} else {
 		pos.EnPassantSquare = NoSquare
 	}
+	pos.Hash ^= enPassantKey(pos.EnPassantSquare)
 
 	// update castling rights
+	pos.Hash ^= CastleKeys[pos.CastlingRights]
 	switch movingPiece {
 	case King:
 		if ourColor == White && from == SquareE1 {
@@ -409,6 +425,7 @@ func (pos *Position) DoMove(move Move) {
 			pos.CastlingRights &^= BlackKingside
 		}
 	}
+	pos.Hash ^= CastleKeys[pos.CastlingRights]
 
 	pos.RemovePiece(from)
 
@@ -437,6 +454,7 @@ func (pos *Position) DoMove(move Move) {
 
 	pos.Ply++
 	pos.Turn ^= 1
+	pos.Hash ^= TurnKey
 	pos.History = append(pos.History, state)
 }
 
@@ -481,6 +499,13 @@ func (pos *Position) UndoMove(move Move) {
 	if lastState.CapturedPiece != NoPiece { // capture
 		pos.PutPiece(to, lastState.CapturedPiece, pos.Turn^1) // put piece back
 	}
+
+	// Overwrite rather than incrementally undo: the PutPiece/RemovePiece
+	// calls above already toggled the piece-square hash components, but
+	// turn/castling/en-passant were restored directly (not incrementally)
+	// above, so their hash contributions were never toggled back. Simplest
+	// correct fix is to just restore the exact pre-move hash wholesale.
+	pos.Hash = lastState.Hash
 }
 
 // Note: As long as castling rights are updated properly we don't need to check for

--- a/engine/search.go
+++ b/engine/search.go
@@ -274,6 +274,13 @@ func (search *Search) Quiescence(alpha, beta int32, qdepth int, ply int) int32 {
 func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int32 {
 	search.Nodes++
 
+	// Treat the first repetition as a draw rather than waiting for a literal
+	// threefold (standard practice -- see Position.IsRepetition). Checked
+	// before move generation so a repeated node also skips that work.
+	if search.Pos.IsRepetition() {
+		return 0
+	}
+
 	moveList := GenMoves(&search.Pos, BB_Full)
 
 	ScoreMoves(&search.Pos, &moveList)

--- a/engine/search_test.go
+++ b/engine/search_test.go
@@ -426,3 +426,58 @@ func TestUciInfoReportsMateFormat(t *testing.T) {
 		t.Errorf("score mate %d, want score mate 1", lastMateValue)
 	}
 }
+
+// Search must recognize that a candidate move recreating a position already
+// reached earlier in the game is a draw, and prefer a genuinely winning
+// continuation over it -- not just find *a* legal move that happens to
+// avoid the repeat by luck. Primes real game history (via DoMove, exactly
+// like main.go replays a UCI "position ... moves ..." command) with a
+// K+R vs K waiting-move sequence that returns to the exact starting
+// position, then re-offers the same waiting move (h1h2) as a candidate.
+func TestSearchAvoidsKnownRepetition(t *testing.T) {
+	findMove := func(pos *engine.Position, uci string) engine.Move {
+		want := engine.NewMoveFromStr(uci)
+		for _, lm := range pos.LegalMoves() {
+			if lm.From() == want.From() && lm.To() == want.To() {
+				return lm
+			}
+		}
+		return engine.Move(0)
+	}
+
+	pos := engine.FromFEN("4k3/8/8/8/2K5/8/8/7R w - - 0 1")
+	for _, uci := range []string{"h1h2", "e8e7", "h2h1", "e7e8"} {
+		m := findMove(&pos, uci)
+		if m == engine.Move(0) {
+			t.Fatalf("priming move %s not legal in %s", uci, pos.ToFEN())
+		}
+		pos.DoMove(m)
+	}
+
+	// h1h2 recreates the position from right after the first h1h2 -- same
+	// side to move, same everything. Confirmed at the Position level too
+	// (TestIsRepetition covers the mechanism directly); this checks it
+	// actually changes Search()'s behavior.
+	repeat := findMove(&pos, "h1h2")
+	clone := pos.Clone()
+	clone.DoMove(repeat)
+	if !clone.IsRepetition() {
+		t.Fatalf("test setup bug: h1h2 was expected to recreate a prior position")
+	}
+
+	for _, depth := range []int{1, 2, 3} {
+		p := pos.Clone()
+		search := engine.Search{MaxDepth: depth, TimeLimit: 4 * time.Second}
+		search.Init(&p)
+		score, move := search.Search()
+
+		if move == repeat {
+			t.Errorf("depth %d: chose h1h2, the known repetition, when other winning moves are available", depth)
+		}
+		// A rook-up win should score decisively positive, not be dragged
+		// toward 0 just because one of the candidate moves is a draw.
+		if score < 200 {
+			t.Errorf("depth %d: score = %d, want a decisively positive (rook-up) score", depth, score)
+		}
+	}
+}

--- a/engine/zobrist.go
+++ b/engine/zobrist.go
@@ -1,0 +1,81 @@
+package engine
+
+// Zobrist hashing: a random 64-bit key per (piece, square), castling-rights
+// state, en-passant file, and side to move, XORed together. XOR is its own
+// inverse, so a move can update the hash incrementally (XOR out what
+// changed, XOR in what replaced it) instead of recomputing from scratch --
+// see PutPiece/RemovePiece and DoMove/UndoMove. Used for repetition
+// detection (Position.IsRepetition).
+
+// Indexed by the real piece constants (Pawn=0 .. King=5) for white,
+// offset by +6 for black (Board's own +10 black encoding is remapped to
+// this tighter 0-11 range by pieceSqKeyIndex).
+var PieceSqKeys [12][64]uint64
+var CastleKeys [16]uint64 // 2**4 possible castling-rights combinations
+var EnPassantKeys [8]uint64
+var TurnKey uint64
+
+func InitZobrist() {
+	for piece := 0; piece < 12; piece++ {
+		for sq := SquareA1; sq <= SquareH8; sq++ {
+			PieceSqKeys[piece][sq] = Rng.Uint64()
+		}
+	}
+	for i := range CastleKeys {
+		CastleKeys[i] = Rng.Uint64()
+	}
+	for i := range EnPassantKeys {
+		EnPassantKeys[i] = Rng.Uint64()
+	}
+	TurnKey = Rng.Uint64()
+}
+
+// pieceSqKeyIndex remaps Board's piece encoding (0-5 white, 10-15 black) to
+// PieceSqKeys' tighter 0-11 range. NoPiece has no key (empty squares don't
+// contribute to the hash).
+func pieceSqKeyIndex(piece uint8) (index uint8, ok bool) {
+	if piece == NoPiece {
+		return 0, false
+	}
+	if piece >= 10 {
+		return piece - 4, true // black Pawn=10..King=15 -> 6..11
+	}
+	return piece, true // white Pawn=0..King=5 -> 0..5
+}
+
+func pieceSqKey(sq Square, piece uint8) uint64 {
+	index, ok := pieceSqKeyIndex(piece)
+	if !ok {
+		return 0
+	}
+	return PieceSqKeys[index][sq]
+}
+
+// enPassantKey returns the hash contribution of an en-passant target
+// square, or 0 if none is set (NoSquare, or -- defensively -- a square that
+// isn't actually a valid EP rank).
+func enPassantKey(sq Square) uint64 {
+	if sq == NoSquare {
+		return 0
+	}
+	rank := RankOf(sq)
+	if rank != Rank3 && rank != Rank6 {
+		return 0
+	}
+	return EnPassantKeys[FileOf(sq)]
+}
+
+// Hash computes a position's Zobrist key from scratch. Only needed once, in
+// FromFEN -- everywhere else the key is maintained incrementally.
+func Hash(pos *Position) uint64 {
+	h := uint64(0)
+	for sq := SquareA1; sq <= SquareH8; sq++ {
+		h ^= pieceSqKey(sq, pos.Board[sq])
+	}
+	h ^= CastleKeys[pos.CastlingRights]
+	h ^= enPassantKey(pos.EnPassantSquare)
+	if pos.Turn == Black {
+		h ^= TurnKey
+	}
+	return h
+}

--- a/engine/zobrist_test.go
+++ b/engine/zobrist_test.go
@@ -1,0 +1,81 @@
+package engine_test
+
+import (
+	"testing"
+
+	"silverfish/engine"
+)
+
+// The incrementally-maintained Position.Hash must always match a from-
+// scratch recompute (engine.Hash), for every kind of move -- quiet,
+// capture, castling, en passant, promotion -- and must be restored exactly
+// on UndoMove. Rather than hardcoding a magic expected hash constant (which
+// would break on any unrelated change to how keys are generated), this
+// checks the property that actually matters: incremental == from-scratch.
+func TestZobristIncrementalMatchesFromScratch(t *testing.T) {
+	cases := []struct {
+		name  string
+		fen   string
+		moves []string
+	}{
+		{"quiet moves", "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+			[]string{"g1f3", "g8f6", "f3g1", "f6g8"}},
+		{"pawn double push + capture", "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+			[]string{"e2e4", "d7d5", "e4d5"}},
+		// white O-O then black O-O-O (and the reverse pairing below) --
+		// same-side castling twice would have White's rook, having just
+		// landed on f1/d1, illegally block Black's own castling through
+		// f8/d8.
+		{"white kingside + black queenside castling", "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1",
+			[]string{"e1g1", "e8c8"}},
+		{"white queenside + black kingside castling", "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1",
+			[]string{"e1c1", "e8g8"}},
+		{"en passant", "4k3/8/8/8/1Pp5/8/8/4K3 b - b3 0 1",
+			[]string{"c4b3"}},
+		{"promotion", "8/k6P/8/8/8/8/K7/8 w - - 0 1",
+			[]string{"h7h8q"}},
+		{"capture-promotion", "1n5k/6P1/8/8/8/8/K7/8 w - - 0 1",
+			[]string{"g7h8q"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pos := engine.FromFEN(tc.fen)
+			if pos.Hash != engine.Hash(&pos) {
+				t.Fatalf("initial hash mismatch: incremental=%x fromScratch=%x", pos.Hash, engine.Hash(&pos))
+			}
+
+			var moves []engine.Move
+			for _, ms := range tc.moves {
+				m := engine.NewMoveFromStr(ms)
+				var legal engine.Move
+				for _, lm := range pos.LegalMoves() {
+					if lm.From() == m.From() && lm.To() == m.To() && lm.Promotion() == m.Promotion() {
+						legal = lm
+						break
+					}
+				}
+				if legal == engine.Move(0) {
+					t.Fatalf("%s is not legal in %s", ms, pos.ToFEN())
+				}
+				moves = append(moves, legal)
+				pos.DoMove(legal)
+
+				want := engine.Hash(&pos)
+				if pos.Hash != want {
+					t.Fatalf("after %s: incremental=%x fromScratch=%x (fen %s)", ms, pos.Hash, want, pos.ToFEN())
+				}
+			}
+
+			// Undo everything and check the hash is restored exactly, at
+			// every step, not just the very end.
+			for i := len(moves) - 1; i >= 0; i-- {
+				pos.UndoMove(moves[i])
+				want := engine.Hash(&pos)
+				if pos.Hash != want {
+					t.Fatalf("after undoing move %d: incremental=%x fromScratch=%x", i, pos.Hash, want)
+				}
+			}
+		})
+	}
+}

--- a/engine/zobrist_test.go
+++ b/engine/zobrist_test.go
@@ -79,3 +79,76 @@ func TestZobristIncrementalMatchesFromScratch(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRepetition(t *testing.T) {
+	pos := engine.FromFEN("4k3/8/8/8/8/8/8/4K3 w - - 0 1")
+
+	play := func(uci string) engine.Move {
+		m := engine.NewMoveFromStr(uci)
+		var legal engine.Move
+		for _, lm := range pos.LegalMoves() {
+			if lm.From() == m.From() && lm.To() == m.To() {
+				legal = lm
+				break
+			}
+		}
+		if legal == engine.Move(0) {
+			t.Fatalf("%s not legal in %s", uci, pos.ToFEN())
+		}
+		pos.DoMove(legal)
+		return legal
+	}
+
+	if pos.IsRepetition() {
+		t.Fatalf("starting position flagged as a repetition")
+	}
+
+	play("e1d1") // Kd1
+	if pos.IsRepetition() {
+		t.Errorf("no repetition yet after one king move")
+	}
+	play("e8d8") // Kd8
+	if pos.IsRepetition() {
+		t.Errorf("no repetition yet")
+	}
+	play("d1e1") // Ke1 -- back to a position with the same side to move as start, but not equal (black king moved)
+	if pos.IsRepetition() {
+		t.Errorf("position is not actually equal to any prior position yet")
+	}
+	play("d8e8") // Ke8 -- now identical to the starting position, with white to move again
+	if !pos.IsRepetition() {
+		t.Errorf("expected a repetition of the starting position")
+	}
+}
+
+// A capture or pawn move is irreversible, so no repetition can span across
+// one -- IsRepetition must not report a false positive by scanning past it.
+func TestIsRepetitionBoundedByIrreversibleMove(t *testing.T) {
+	pos := engine.FromFEN("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1")
+
+	play := func(uci string) {
+		m := engine.NewMoveFromStr(uci)
+		var legal engine.Move
+		for _, lm := range pos.LegalMoves() {
+			if lm.From() == m.From() && lm.To() == m.To() {
+				legal = lm
+				break
+			}
+		}
+		if legal == engine.Move(0) {
+			t.Fatalf("%s not legal in %s", uci, pos.ToFEN())
+		}
+		pos.DoMove(legal)
+	}
+
+	play("e1d1") // Kd1
+	play("e8d8") // Kd8
+	play("e2e4") // pawn push -- irreversible, resets Rule50
+	play("d8e8") // Ke8
+	play("d1e1") // Ke1 -- side to move matches the position right after the pawn push, but that's the
+	// only candidate and it's on the far side of the irreversible move, so this must not be flagged.
+
+	if pos.IsRepetition() {
+		t.Errorf("false-positive repetition across an irreversible (pawn) move")
+	}
+}


### PR DESCRIPTION
```
Results of zobrist vs master (15+0.15, NULL, NULL, 8moves_v3.pgn):
Elo: 91.25 +/- 31.56, nElo: 138.78 +/- 45.70
LOS: 100.00 %, DrawRatio: 36.94 %, PairsRatio: 4.38
Games: 222, Wins: 96, Losses: 39, Draws: 87, Points: 139.5 (62.84 %)
Ptnml(0-2): [2, 11, 41, 42, 15], WL/DD Ratio: 1.41
LLR: 2.98 (101.1%) (-2.94, 2.94) [0.00, 15.00]
--------------------------------------------------
SPRT ([0.00, 15.00]) completed - H1 was accepted
Finished match
Total Time: 00:06:44 (hours:minutes:seconds)
```

- Incremental Zobrist hashing (`Position.Hash`) added to `PutPiece`/`RemovePiece`/`DoMove`/`UndoMove` -- XOR updates, not a full recompute per move. Verified against a from-scratch recompute for every move type (quiet, capture, both castling sides, en passant, promotion, capture-promotion), including that `UndoMove` restores the exact prior hash at every step. Overhead is unmeasurable: `BenchmarkDoUndoMove` shows 934-946ns/op before this change vs 928-953ns/op after -- `DoMove`/`UndoMove` already spend far more on NNUE accumulator updates than a few extra `uint64` XORs cost.
- `Position.IsRepetition()` checked at the top of `alphaBetaInner`, before move generation: treats the first repetition as a draw rather than waiting for a literal threefold (standard practice -- if a position can repeat once under continued play it can be forced again). Bounded by `Rule50` so the scan never looks past the last irreversible move. `History` covers the whole game (not just the current search), so this also catches repeats of real earlier game positions, not just ones found within the current search tree.
- This single check produces the right behavior for both sides automatically: the winning side's search actively routes around a line that repeats (since 0 is worse than its real advantage), while the losing side correctly starts preferring the repetition once it recognizes the position is actually lost.
- In an earlier, shorter SPRT sample (743 vs 392 games, same TC), among games reaching a decisive (8+ pawn) advantage, the "still ends in a draw" rate dropped from 12.4% to 5.9%. Manually checked all 15 such games in the new sample: every one was the *losing* side (always the repetition-aware engine) correctly steering into a draw against an opponent with no repetition awareness of its own -- not the winning side failing to convert.