### PR TITLE
Basic transposition table

### DIFF
--- a/cmd/silverfish/main.go
+++ b/cmd/silverfish/main.go
@@ -125,6 +125,8 @@ mainloop:
 				engine.UciReadyOk()
 			case engine.UciPositionClientMessage:
 				position = message.Position.Clone()
+			case engine.UciNewGameClientMessage:
+				engine.ClearTT()
 			case engine.UciQuitClientMessage:
 				break mainloop
 			case engine.UciGoClientMessage:

--- a/engine/init.go
+++ b/engine/init.go
@@ -11,6 +11,7 @@ var defaultNet *Network
 func Init() {
 	InitBitboard()
 	InitZobrist()
+	allocTT(TTSizeMB)
 	if err := LoadDefaultNetwork(""); err != nil {
 		panic("engine: failed to load default NNUE network: " + err.Error())
 	}

--- a/engine/search.go
+++ b/engine/search.go
@@ -107,6 +107,27 @@ func OrderMoves(pos *Position, moveList *MoveList) {
 	}
 }
 
+// orderMoveFirst swaps the move matching target to the front of moveList,
+// if present. Move's top 16 bits are a mutable score field the TT never
+// stores, so target is compared on its low 16 bits only. A target of 0 or
+// one that doesn't match any generated move (a stale or index-collided TT
+// entry, or a move that's simply no longer legal here) is a safe no-op --
+// this only ever reorders, it's never relied on for correctness.
+func orderMoveFirst(moveList *MoveList, target Move) {
+	if target == 0 {
+		return
+	}
+	target &= 0xffff
+	for i := uint8(0); i < moveList.Count; i++ {
+		if moveList.Moves[i]&0xffff == target {
+			if i != 0 {
+				moveList.Moves[0], moveList.Moves[i] = moveList.Moves[i], moveList.Moves[0]
+			}
+			return
+		}
+	}
+}
+
 func (search *Search) Init(pos *Position) {
 	search.Pos = pos.Clone()
 }
@@ -129,6 +150,14 @@ func (search *Search) Search() (int32, Move) {
 	for depth := 1; depth <= search.MaxDepth; depth++ {
 		alpha := -Infinity
 		beta := Infinity
+
+		// Put the previous iteration's best move (stored by this same loop,
+		// one depth ago) first -- gives PV-move-first ordering across
+		// iterative-deepening iterations, not just within a single
+		// alphaBetaInner call.
+		if entry, ok := TTProbe(search.Pos.Hash); ok {
+			orderMoveFirst(&moveList, entry.Move)
+		}
 
 		bestScoreCurr := -Infinity
 		var bestMoveCurr Move
@@ -173,6 +202,14 @@ func (search *Search) Search() (int32, Move) {
 			if bestMoveCurr != Move(0) {
 				bestScore = bestScoreCurr
 				bestMove = bestMoveCurr
+
+				// Only a fully-completed depth's result is trustworthy
+				// enough to mark Exact (a timed-out partial pass didn't
+				// finish comparing every root move). Stored so the next
+				// iteration's probe above can order this move first.
+				if !timedOut {
+					TTStore(search.Pos.Hash, bestMove, ScoreToTT(bestScore, 0), depth, BoundExact)
+				}
 
 				// Reported once per completed depth, with that depth's own
 				// final score -- not per move, and not a stale score left
@@ -281,10 +318,29 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 		return 0
 	}
 
+	alphaOrig := alpha
+
+	var ttMove Move
+	if entry, ok := TTProbe(search.Pos.Hash); ok {
+		ttMove = entry.Move
+		if int(entry.Depth) >= depth {
+			s := ScoreFromTT(entry.Score, ply)
+			switch {
+			case entry.Bound == BoundExact:
+				return s
+			case entry.Bound == BoundLower && s >= beta:
+				return s
+			case entry.Bound == BoundUpper && s <= alpha:
+				return s
+			}
+		}
+	}
+
 	moveList := GenMoves(&search.Pos, BB_Full)
 
 	ScoreMoves(&search.Pos, &moveList)
 	OrderMoves(&search.Pos, &moveList)
+	orderMoveFirst(&moveList, ttMove)
 
 	hasLegal := false
 
@@ -304,6 +360,7 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 	}
 
 	bestScore := -Infinity
+	var bestMove Move
 	for i := uint8(0); i < moveList.Count; i++ {
 		move := moveList.Moves[i]
 		if !search.Pos.MoveIsLegal(move) {
@@ -316,10 +373,12 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 		search.Pos.UndoMove(move)
 
 		if score >= beta {
+			TTStore(search.Pos.Hash, move, ScoreToTT(score, ply), depth, BoundLower)
 			return score
 		}
 		if score > bestScore {
 			bestScore = score
+			bestMove = move
 		}
 		if score > alpha {
 			alpha = score
@@ -349,6 +408,12 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 			return 0
 		}
 	}
+
+	bound := BoundExact
+	if bestScore <= alphaOrig {
+		bound = BoundUpper
+	}
+	TTStore(search.Pos.Hash, bestMove, ScoreToTT(bestScore, ply), depth, bound)
 
 	return bestScore
 }

--- a/engine/search_test.go
+++ b/engine/search_test.go
@@ -317,6 +317,35 @@ func TestSearchPrefersFasterMate(t *testing.T) {
 	}
 }
 
+// Mate scores are ply-relative, so a TT entry storing one must be re-based
+// (via ScoreToTT/ScoreFromTT) when reused from a different ply -- otherwise
+// the reported mate distance corrupts. This runs a known mate-in-1 across
+// several MaxDepths so the position is reached, cached, and reprobed at
+// different plies (and iterations) within iterative-deepening searches,
+// and checks the move found is still an immediate, genuine checkmate every
+// time -- not just a mate-scored move that happens to not actually mate,
+// which is exactly what a corrupted ply rebasing would produce.
+func TestSearchMateDistanceCorrectThroughTT(t *testing.T) {
+	engine.ClearTT()
+
+	fen := "6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 1" // mate in 1 (Ra8#)
+	for _, maxDepth := range []int{2, 3, 4, 5} {
+		pos := engine.FromFEN(fen)
+		search := engine.Search{MaxDepth: maxDepth, TimeLimit: 4 * time.Second}
+		search.Init(&pos)
+
+		score, bestMove := search.Search()
+		if score < engine.Infinity-10 {
+			t.Fatalf("MaxDepth=%d: score = %d, want a mate score near +Infinity", maxDepth, score)
+		}
+
+		pos.DoMove(bestMove)
+		if len(pos.LegalMoves()) != 0 || pos.Checkers(pos.Turn) == 0 {
+			t.Errorf("MaxDepth=%d: move %s is not checkmate (mate distance likely corrupted by a stale TT ply)", maxDepth, bestMove.ToString())
+		}
+	}
+}
+
 // A free, undefended piece with no counterplay must be captured by any
 // correct search -- independent of eval tuning, since forfeiting it is a
 // clear material loss under any reasonable evaluation.

--- a/engine/tt.go
+++ b/engine/tt.go
@@ -1,0 +1,109 @@
+package engine
+
+// Transposition table: caches search results keyed by Position.Hash, so a
+// position reached by a different move order is not re-searched from
+// scratch, and (usually the bigger win) so the best move found last time is
+// available to order search at every node on every iterative-deepening
+// pass.
+
+const (
+	BoundNone uint8 = iota
+	BoundExact       // Score is the position's true value.
+	BoundLower       // Fail-high: the true value is >= Score.
+	BoundUpper       // Fail-low: the true value is <= Score.
+)
+
+// TTSizeMB is deliberately modest for a first implementation -- SPRT runs
+// many engine instances concurrently on one machine, so this is per-process
+// resident memory, not a one-off cost.
+const TTSizeMB = 16
+
+type TTEntry struct {
+	Key   uint64
+	Move  Move // low 16 bits only -- Move's bits 16+ are a mutable score field, never compared/stored.
+	Score int32
+	Depth int16
+	Bound uint8
+}
+
+const ttEntrySize = 32 // approx size of TTEntry in bytes, rounded up to a power of 2 for a clean table size
+
+var tt []TTEntry
+var ttMask uint64
+
+// allocTT allocates the transposition table. Called from Init().
+func allocTT(sizeMB int) {
+	numEntries := sizeMB * 1024 * 1024 / ttEntrySize
+	// round down to a power of two so key&ttMask is a valid index
+	pow := 1
+	for pow*2 <= numEntries {
+		pow *= 2
+	}
+	tt = make([]TTEntry, pow)
+	ttMask = uint64(pow - 1)
+}
+
+// ClearTT resets the transposition table. Should be called on ucinewgame:
+// stale entries from a previous game are still key-verified before use, but
+// clearing avoids wasting the table on positions that can't recur.
+func ClearTT() {
+	for i := range tt {
+		tt[i] = TTEntry{}
+	}
+}
+
+// TTProbe returns the entry for key and whether it was found. A non-zero
+// Move field is usable for ordering even when the caller can't use the
+// score itself (e.g. insufficient stored depth).
+func TTProbe(key uint64) (TTEntry, bool) {
+	e := tt[key&ttMask]
+	if e.Bound == BoundNone || e.Key != key {
+		return TTEntry{}, false
+	}
+	return e, true
+}
+
+// TTStore records a search result. Replacement is simple depth-preferred:
+// an incoming entry always wins on an empty slot, a different key (a
+// collision -- always replacing avoids permanently wedging a stale entry
+// from a different position into that slot), or when it comes from at
+// least as deep a search as what's already there.
+func TTStore(key uint64, move Move, score int32, depth int, bound uint8) {
+	idx := key & ttMask
+	existing := &tt[idx]
+	if existing.Bound == BoundNone || existing.Key != key || int16(depth) >= existing.Depth {
+		*existing = TTEntry{
+			Key:   key,
+			Move:  move & 0xffff,
+			Score: score,
+			Depth: int16(depth),
+			Bound: bound,
+		}
+	}
+}
+
+// ScoreToTT/ScoreFromTT convert between a node-relative score (as used
+// throughout the search) and a root-relative score (as stored in the
+// table). Mate scores are ply-relative -- "mate in N plies from here" --
+// so a mate score stored at one ply and probed at a different ply must be
+// re-based by the difference, or the reported mate distance corrupts.
+// Non-mate scores are ply-independent and pass through unchanged.
+func ScoreToTT(score int32, ply int) int32 {
+	if score >= MateScoreThreshold {
+		return score + int32(ply)
+	}
+	if score <= -MateScoreThreshold {
+		return score - int32(ply)
+	}
+	return score
+}
+
+func ScoreFromTT(score int32, ply int) int32 {
+	if score >= MateScoreThreshold {
+		return score - int32(ply)
+	}
+	if score <= -MateScoreThreshold {
+		return score + int32(ply)
+	}
+	return score
+}

--- a/engine/tt_test.go
+++ b/engine/tt_test.go
@@ -1,0 +1,159 @@
+package engine_test
+
+import (
+	"testing"
+
+	"silverfish/engine"
+)
+
+func TestScoreToFromTTRoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		score int32
+		ply   int
+	}{
+		{"zero", 0, 5},
+		{"ordinary positive eval", 350, 7},
+		{"ordinary negative eval", -820, 3},
+		{"mate for us, found at root", engine.Infinity - 1, 0},
+		{"mate for us, found deep", engine.Infinity - 1, 12},
+		{"mate against us, found deep", -(engine.Infinity - 1), 9},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stored := engine.ScoreToTT(tc.score, tc.ply)
+			got := engine.ScoreFromTT(stored, tc.ply)
+			if got != tc.score {
+				t.Errorf("round-trip at ply %d: got %d, want %d (stored intermediate was %d)", tc.ply, got, tc.score, stored)
+			}
+		})
+	}
+}
+
+// A mate score stored at one ply and probed at a different ply (as happens
+// when the same position is reached via a different, shorter or longer,
+// path) must re-base to the correct mate distance from the new ply -- this
+// is the exact class of corruption that made the old tt branch play badly.
+func TestScoreToFromTTRebasesMateAcrossPlies(t *testing.T) {
+	// A mate found 3 plies from the node where it's stored.
+	nodeRelative := engine.Infinity - 3
+	stored := engine.ScoreToTT(nodeRelative, 10) // stored while at ply 10 -> root-relative mate at ply 13
+
+	// Probed again at a different ply: stored = nodeRelative + 10 (the ply
+	// at store time), so probing at ply 5 must yield stored - 5 -- follows
+	// directly from the store/probe formulas, independent of what those
+	// numbers mean chess-wise.
+	gotAtPly5 := engine.ScoreFromTT(stored, 5)
+	wantAtPly5 := stored - 5
+	if gotAtPly5 != wantAtPly5 {
+		t.Errorf("re-based mate score at ply 5 = %d, want %d", gotAtPly5, wantAtPly5)
+	}
+
+	gotAtPly10 := engine.ScoreFromTT(stored, 10)
+	if gotAtPly10 != nodeRelative {
+		t.Errorf("re-based mate score at original ply 10 = %d, want %d", gotAtPly10, nodeRelative)
+	}
+}
+
+func TestTTStoreAndProbe(t *testing.T) {
+	engine.ClearTT()
+
+	pos := engine.StartingPosition()
+	move := engine.NewMoveFromStr("e2e4")
+
+	engine.TTStore(pos.Hash, move, 123, 4, engine.BoundExact)
+
+	entry, ok := engine.TTProbe(pos.Hash)
+	if !ok {
+		t.Fatalf("expected a hit after store")
+	}
+	if entry.Score != 123 || entry.Depth != 4 || entry.Bound != engine.BoundExact {
+		t.Errorf("got entry %+v, want score=123 depth=4 bound=Exact", entry)
+	}
+	if entry.Move.From() != move.From() || entry.Move.To() != move.To() {
+		t.Errorf("got move %v, want %v", entry.Move, move)
+	}
+}
+
+func TestTTMoveIsMaskedToLow16Bits(t *testing.T) {
+	engine.ClearTT()
+
+	move := engine.NewMoveFromStr("e2e4")
+	move.GiveScore(999) // sets bits 16+, as move ordering does in practice
+
+	engine.TTStore(0xabc, move, 0, 1, engine.BoundExact)
+	entry, ok := engine.TTProbe(0xabc)
+	if !ok {
+		t.Fatalf("expected a hit")
+	}
+	if entry.Move.Score() != 0 {
+		t.Errorf("stored move retained a score field (%d) -- should be masked to the low 16 bits", entry.Move.Score())
+	}
+}
+
+// A probe with a key that maps to the same table index but is not actually
+// equal must not be treated as a hit -- otherwise a hash collision returns
+// a completely unrelated position's cached result.
+func TestTTProbeRejectsIndexCollision(t *testing.T) {
+	engine.ClearTT()
+
+	keyA := uint64(0x1122334455667788)
+	engine.TTStore(keyA, engine.NewMoveFromStr("e2e4"), 50, 3, engine.BoundExact)
+
+	// Same low bits (same table index under any power-of-two mask), but a
+	// different full 64-bit key.
+	keyB := keyA ^ (uint64(1) << 40)
+
+	_, ok := engine.TTProbe(keyB)
+	if ok {
+		t.Errorf("probe with a colliding-but-different key returned a hit")
+	}
+
+	// The original key must still be retrievable.
+	entry, ok := engine.TTProbe(keyA)
+	if !ok || entry.Score != 50 {
+		t.Errorf("original key no longer retrievable after a colliding probe: ok=%v entry=%+v", ok, entry)
+	}
+}
+
+func TestTTStorePrefersDeeperOnCollision(t *testing.T) {
+	engine.ClearTT()
+
+	keyA := uint64(0x1)
+	// Force a collision by finding another key with the same low bits under
+	// a very large table -- simplest reliable way is to store at the same
+	// key twice with different depths, which also exercises the "same key,
+	// deeper replaces shallower" path directly used during real search
+	// (repeated probes/stores of the same position at increasing ID depth).
+	engine.TTStore(keyA, engine.NewMoveFromStr("e2e4"), 10, 2, engine.BoundExact)
+	engine.TTStore(keyA, engine.NewMoveFromStr("d2d4"), 20, 5, engine.BoundExact)
+
+	entry, ok := engine.TTProbe(keyA)
+	if !ok {
+		t.Fatalf("expected a hit")
+	}
+	if entry.Depth != 5 || entry.Score != 20 {
+		t.Errorf("got depth=%d score=%d, want the deeper store (depth=5 score=20) to win", entry.Depth, entry.Score)
+	}
+
+	// A shallower store for the same key must NOT overwrite the deeper one.
+	engine.TTStore(keyA, engine.NewMoveFromStr("g1f3"), 30, 1, engine.BoundExact)
+	entry, _ = engine.TTProbe(keyA)
+	if entry.Depth != 5 || entry.Score != 20 {
+		t.Errorf("a shallower store overwrote a deeper entry: got depth=%d score=%d", entry.Depth, entry.Score)
+	}
+}
+
+func TestClearTT(t *testing.T) {
+	engine.TTStore(0x42, engine.NewMoveFromStr("e2e4"), 100, 5, engine.BoundExact)
+	if _, ok := engine.TTProbe(0x42); !ok {
+		t.Fatalf("expected a hit before clearing")
+	}
+
+	engine.ClearTT()
+
+	if _, ok := engine.TTProbe(0x42); ok {
+		t.Errorf("expected no hit after ClearTT")
+	}
+}

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -52,6 +52,7 @@ const (
 	UciQuitClientMessage
 	UciStopClientMessage
 	UciSetOptionClientMessage
+	UciNewGameClientMessage
 )
 
 // EvalFileDefaultLabel is the sentinel value UCI GUIs are expected to send
@@ -211,6 +212,9 @@ func UciProcessClientMessage(stdin *bufio.Scanner) UciClientMessage {
 		opt := uciProcessSetOptionMessage(strings.TrimPrefix(textMessage, "setoption "))
 		message.SetOption = &opt
 		message.MessageType = UciSetOptionClientMessage
+		return message
+	} else if textMessage == "ucinewgame" {
+		message.MessageType = UciNewGameClientMessage
 		return message
 	}
 

--- a/engine/uci_test.go
+++ b/engine/uci_test.go
@@ -1,0 +1,17 @@
+package engine_test
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"silverfish/engine"
+)
+
+func TestUciProcessClientMessageParsesNewGame(t *testing.T) {
+	scanner := bufio.NewScanner(strings.NewReader("ucinewgame\n"))
+	message := engine.UciProcessClientMessage(scanner)
+	if message.MessageType != engine.UciNewGameClientMessage {
+		t.Errorf("got MessageType %d, want UciNewGameClientMessage", message.MessageType)
+	}
+}

--- a/engine/zobrist_test.go
+++ b/engine/zobrist_test.go
@@ -152,3 +152,34 @@ func TestIsRepetitionBoundedByIrreversibleMove(t *testing.T) {
 		t.Errorf("false-positive repetition across an irreversible (pawn) move")
 	}
 }
+
+// Guards against a real historical bug (the dead `tt` branch): its
+// InitZobrist only seeded PieceSqKeys rows 0-5, leaving black's rows (6-11)
+// permanently zero, so every black piece contributed nothing to the hash
+// and positions differing only in black's material/placement hashed
+// identically. The incremental-vs-from-scratch test above can't catch this
+// (it would still agree with itself even if every key were zero), so this
+// checks the property that actually matters for a transposition table: no
+// key is zero, and two positions differing only in a black piece hash
+// differently.
+func TestZobristKeysAreNonZeroAndDistinctForBlackPieces(t *testing.T) {
+	for piece := 0; piece < 12; piece++ {
+		for sq := engine.SquareA1; sq <= engine.SquareH8; sq++ {
+			if engine.PieceSqKeys[piece][sq] == 0 {
+				t.Fatalf("PieceSqKeys[%d][%d] is zero (uninitialized key)", piece, sq)
+			}
+		}
+	}
+
+	withBlackKnight := engine.FromFEN("4k3/8/8/8/8/8/8/n3K3 w - - 0 1")
+	withoutBlackKnight := engine.FromFEN("4k3/8/8/8/8/8/8/4K3 w - - 0 1")
+	if withBlackKnight.Hash == withoutBlackKnight.Hash {
+		t.Fatalf("positions differing only by a black knight hash identically (%x)", withBlackKnight.Hash)
+	}
+
+	blackKnightA1 := engine.FromFEN("4k3/8/8/8/8/8/8/n3K3 w - - 0 1")
+	blackKnightH1 := engine.FromFEN("4k3/8/8/8/8/8/8/4K2n w - - 0 1")
+	if blackKnightA1.Hash == blackKnightH1.Hash {
+		t.Fatalf("a black knight on different squares hashes identically (%x)", blackKnightA1.Hash)
+	}
+}


### PR DESCRIPTION
- Adds a fixed-size (16MB), depth-preferred-replacement transposition table, keyed by the incremental Zobrist hash added in #8.
- Probes/stores in `alphaBetaInner` only (not quiescence, no aspiration windows -- deliberately scoped as a first, basic implementation).
- Uses the TT move for ordering at every internal node (regardless of whether the stored depth is deep enough for a cutoff), and re-orders the root move list at the start of each iterative-deepening iteration using the previous iteration's stored best move -- gives PV-move-first ordering across ID iterations, which the root previously had no mechanism for at all.
- No cutoff at the root itself (would risk returning a score without a legal move on a corrupted/incomplete entry) -- the root only uses the TT for move ordering.
- Adds `ucinewgame` parsing (previously silently unhandled) and clears the table on it.

### Background

A previous attempt at a TT (`origin/tt`, dead branch) reportedly made the engine "play extremely poor moves from the get-go." Forensics on that branch found the TT code itself was never actually wired into the search at all -- the real bug was one ply down, in that branch's Zobrist hashing: `InitZobrist` only seeded piece-square keys for pieces 0-5, leaving black's keys (6-11) permanently zero, so black's position contributed nothing to the hash and positions differing only in black's material hashed identically. The current Zobrist implementation (#8) doesn't have this bug, but its existing tests only checked incremental-vs-from-scratch consistency, which would pass even with all-zero keys -- so this PR starts with a new test that specifically checks key non-zero-ness and hash distinctness for black pieces, closing that blind spot before building anything on top of it.

Mate scores are ply-relative in this engine's scoring convention, so a second, unrelated class of bug this implementation guards against is storing/probing a mate score without re-basing it by ply (`ScoreToTT`/`ScoreFromTT`), which would silently corrupt reported mate distances. Covered by a dedicated regression test that runs a known mate-in-1 across several depths to force TT reuse across iterations.

### Validation

- New tests: Zobrist key non-zero/distinctness, `ScoreToTT`/`ScoreFromTT` round-trip (including ply re-basing across different plies), TT store/probe, index-collision rejection, depth-preferred replacement, `ucinewgame` parsing, and a mate-distance-through-TT regression (mate-in-1 at MaxDepth 2-5, TT populated/reused across iterations, must still resolve to an immediate real checkmate every time).
- Differential fixed-depth comparison (depth 6, TT on vs off) across 4 positions: identical best move in every case, node counts down 2.7x-19x. Two of four scores matched exactly; the other two diverged by 1-49cp -- expected fail-soft alpha-beta behavior (a cut-node's returned score is only a bound, and TT-driven reordering changes which move triggers a given cutoff), not a correctness issue.
- SPRT on orca, `tc=15+0.15`, `elo0=0 elo1=20`:

```
Results of tt vs base (15+0.15, 8moves_v3.pgn):
Elo: 172.05 +/- 54.77, nElo: 231.90 +/- 62.16
LOS: 100.00 %, DrawRatio: 31.67 %
Games: 120, Wins: 77, Losses: 22, Draws: 21, Points: 87.5 (72.92 %)
LLR: 3.01 (-2.94, 2.94) [0.00, 20.00]
SPRT ([0.00, 20.00]) completed - H1 was accepted
```

Only 120 games -- the true effect is far past the elo1=20 upper bound, so it converged almost immediately.

## Out of scope (deliberate, follow-ups)

Aspiration windows, TT in quiescence, UCI `Hash` option / resizable table, entry aging/generation counters, `hashfull`/`pv` in UCI info, smaller entry packing.