### PR TITLE
perf(nnue): fuse accumulator updates, flatten feature columns

### DIFF
--- a/engine/nnue.go
+++ b/engine/nnue.go
@@ -27,7 +27,17 @@ type Network struct {
 	WOutput []float32 // [2 * L1]
 	BOutput float32
 
-	FeatureCols [][]float32
+	// FeatureCols is WInput transposed into per-feature columns, laid out
+	// as one flat contiguous slice ([NumInputs * L1]) rather than a slice
+	// of slices, so column access avoids an extra pointer indirection and
+	// keeps neighboring columns cache-adjacent.
+	FeatureCols []float32
+}
+
+// featureCol returns the L1-length column of weights for feature f.
+func (net *Network) featureCol(f uint16) []float32 {
+	start := int(f) * net.L1
+	return net.FeatureCols[start : start+net.L1]
 }
 
 // Accumulator is the mutable per-position NNUE evaluation state: one
@@ -149,15 +159,13 @@ func loadNNUEFromReader(f io.Reader) (*Network, error) {
 func (net *Network) buildFeatureCols() {
 	numInputs := net.NumInputs
 	l1 := net.L1
-	cols := make([][]float32, numInputs)
+	flat := make([]float32, numInputs*l1)
 	for f := 0; f < numInputs; f++ {
-		col := make([]float32, l1)
 		for o := 0; o < l1; o++ {
-			col[o] = net.WInput[o*numInputs+f]
+			flat[f*l1+o] = net.WInput[o*numInputs+f]
 		}
-		cols[f] = col
 	}
-	net.FeatureCols = cols
+	net.FeatureCols = flat
 }
 
 // NewAccumulator allocates a zeroed accumulator sized for net.
@@ -199,7 +207,7 @@ func (acc *Accumulator) Refresh(net *Network, features []uint16, perspective uin
 	a := acc.Values[perspective]
 	copy(a, net.BInput)
 	for _, f := range features {
-		col := net.FeatureCols[f]
+		col := net.featureCol(f)
 		for o := 0; o < len(a); o += 16 {
 			a[o] += col[o]
 			a[o+1] += col[o+1]
@@ -230,7 +238,7 @@ func (acc *Accumulator) RefreshAll(net *Network, featuresW, featuresB []uint16) 
 // Add incrementally adds a feature. NOTE: only using Add() is incorrect
 // since no bias is added -- Reset() (or RefreshAll) must run first.
 func (acc *Accumulator) Add(net *Network, feature uint16, perspective uint8) {
-	col := net.FeatureCols[feature]
+	col := net.featureCol(feature)
 	a := acc.Values[perspective]
 	for o := 0; o < len(a); o += 16 {
 		a[o] += col[o]
@@ -254,7 +262,7 @@ func (acc *Accumulator) Add(net *Network, feature uint16, perspective uint8) {
 
 // Remove incrementally removes a feature.
 func (acc *Accumulator) Remove(net *Network, feature uint16, perspective uint8) {
-	col := net.FeatureCols[feature]
+	col := net.featureCol(feature)
 	a := acc.Values[perspective]
 	for o := 0; o < len(a); o += 16 {
 		a[o] -= col[o]
@@ -273,6 +281,90 @@ func (acc *Accumulator) Remove(net *Network, feature uint16, perspective uint8) 
 		a[o+13] -= col[o+13]
 		a[o+14] -= col[o+14]
 		a[o+15] -= col[o+15]
+	}
+}
+
+// AddSub applies one added feature and one removed feature in a single pass,
+// halving the memory traffic of a separate Add+Remove for the common case of
+// relocating a piece (quiet move) from one square to another.
+func (acc *Accumulator) AddSub(net *Network, addFeature, subFeature uint16, perspective uint8) {
+	addCol := net.featureCol(addFeature)
+	subCol := net.featureCol(subFeature)
+	a := acc.Values[perspective]
+	for o := 0; o < len(a); o += 16 {
+		a[o] += addCol[o] - subCol[o]
+		a[o+1] += addCol[o+1] - subCol[o+1]
+		a[o+2] += addCol[o+2] - subCol[o+2]
+		a[o+3] += addCol[o+3] - subCol[o+3]
+		a[o+4] += addCol[o+4] - subCol[o+4]
+		a[o+5] += addCol[o+5] - subCol[o+5]
+		a[o+6] += addCol[o+6] - subCol[o+6]
+		a[o+7] += addCol[o+7] - subCol[o+7]
+		a[o+8] += addCol[o+8] - subCol[o+8]
+		a[o+9] += addCol[o+9] - subCol[o+9]
+		a[o+10] += addCol[o+10] - subCol[o+10]
+		a[o+11] += addCol[o+11] - subCol[o+11]
+		a[o+12] += addCol[o+12] - subCol[o+12]
+		a[o+13] += addCol[o+13] - subCol[o+13]
+		a[o+14] += addCol[o+14] - subCol[o+14]
+		a[o+15] += addCol[o+15] - subCol[o+15]
+	}
+}
+
+// AddSubSub applies one added feature and two removed features in a single
+// pass -- used for captures, where the mover relocates (add at `to`, sub at
+// `from`) and the captured piece disappears (sub at `to`).
+func (acc *Accumulator) AddSubSub(net *Network, addFeature, subFeature1, subFeature2 uint16, perspective uint8) {
+	addCol := net.featureCol(addFeature)
+	sub1Col := net.featureCol(subFeature1)
+	sub2Col := net.featureCol(subFeature2)
+	a := acc.Values[perspective]
+	for o := 0; o < len(a); o += 16 {
+		a[o] += addCol[o] - sub1Col[o] - sub2Col[o]
+		a[o+1] += addCol[o+1] - sub1Col[o+1] - sub2Col[o+1]
+		a[o+2] += addCol[o+2] - sub1Col[o+2] - sub2Col[o+2]
+		a[o+3] += addCol[o+3] - sub1Col[o+3] - sub2Col[o+3]
+		a[o+4] += addCol[o+4] - sub1Col[o+4] - sub2Col[o+4]
+		a[o+5] += addCol[o+5] - sub1Col[o+5] - sub2Col[o+5]
+		a[o+6] += addCol[o+6] - sub1Col[o+6] - sub2Col[o+6]
+		a[o+7] += addCol[o+7] - sub1Col[o+7] - sub2Col[o+7]
+		a[o+8] += addCol[o+8] - sub1Col[o+8] - sub2Col[o+8]
+		a[o+9] += addCol[o+9] - sub1Col[o+9] - sub2Col[o+9]
+		a[o+10] += addCol[o+10] - sub1Col[o+10] - sub2Col[o+10]
+		a[o+11] += addCol[o+11] - sub1Col[o+11] - sub2Col[o+11]
+		a[o+12] += addCol[o+12] - sub1Col[o+12] - sub2Col[o+12]
+		a[o+13] += addCol[o+13] - sub1Col[o+13] - sub2Col[o+13]
+		a[o+14] += addCol[o+14] - sub1Col[o+14] - sub2Col[o+14]
+		a[o+15] += addCol[o+15] - sub1Col[o+15] - sub2Col[o+15]
+	}
+}
+
+// AddAddSub applies two added features and one removed feature in a single
+// pass -- the inverse of AddSubSub, used to undo a capture: the mover moves
+// back (add at `from`, sub at `to`) and the captured piece reappears (add at
+// `to`).
+func (acc *Accumulator) AddAddSub(net *Network, addFeature1, addFeature2, subFeature uint16, perspective uint8) {
+	add1Col := net.featureCol(addFeature1)
+	add2Col := net.featureCol(addFeature2)
+	subCol := net.featureCol(subFeature)
+	a := acc.Values[perspective]
+	for o := 0; o < len(a); o += 16 {
+		a[o] += add1Col[o] + add2Col[o] - subCol[o]
+		a[o+1] += add1Col[o+1] + add2Col[o+1] - subCol[o+1]
+		a[o+2] += add1Col[o+2] + add2Col[o+2] - subCol[o+2]
+		a[o+3] += add1Col[o+3] + add2Col[o+3] - subCol[o+3]
+		a[o+4] += add1Col[o+4] + add2Col[o+4] - subCol[o+4]
+		a[o+5] += add1Col[o+5] + add2Col[o+5] - subCol[o+5]
+		a[o+6] += add1Col[o+6] + add2Col[o+6] - subCol[o+6]
+		a[o+7] += add1Col[o+7] + add2Col[o+7] - subCol[o+7]
+		a[o+8] += add1Col[o+8] + add2Col[o+8] - subCol[o+8]
+		a[o+9] += add1Col[o+9] + add2Col[o+9] - subCol[o+9]
+		a[o+10] += add1Col[o+10] + add2Col[o+10] - subCol[o+10]
+		a[o+11] += add1Col[o+11] + add2Col[o+11] - subCol[o+11]
+		a[o+12] += add1Col[o+12] + add2Col[o+12] - subCol[o+12]
+		a[o+13] += add1Col[o+13] + add2Col[o+13] - subCol[o+13]
+		a[o+14] += add1Col[o+14] + add2Col[o+14] - subCol[o+14]
+		a[o+15] += add1Col[o+15] + add2Col[o+15] - subCol[o+15]
 	}
 }
 

--- a/engine/position.go
+++ b/engine/position.go
@@ -132,6 +132,119 @@ func (pos *Position) PutPiecesBB(pieces [2][6]Bitboard) {
 	}
 }
 
+// MovePiece relocates a piece from one square to another (no capture, no
+// promotion), equivalent to RemovePiece(from) followed by PutPiece(to, piece,
+// color) but doing the NNUE accumulator update as a single fused AddSub pass
+// per perspective instead of two separate passes.
+func (pos *Position) MovePiece(from, to Square, piece, color uint8) {
+	fromBB := Bitboard(1 << from)
+	toBB := Bitboard(1 << to)
+
+	boardPieceFrom := pos.Board[from] // pre-adjustment, for the hash key
+	pos.Pieces[color][piece] = pos.Pieces[color][piece]&^fromBB | toBB
+	pos.Blockers = pos.Blockers&^fromBB | toBB
+	pos.Sides[color] = pos.Sides[color]&^fromBB | toBB
+
+	boardPieceTo := piece
+	if color == Black {
+		boardPieceTo += 10
+	}
+	pos.Board[from] = NoPiece
+	pos.Board[to] = boardPieceTo
+
+	pos.Hash ^= pieceSqKey(from, boardPieceFrom)
+	pos.Hash ^= pieceSqKey(to, boardPieceTo)
+
+	fWhiteFrom := FeatureIndex(White, color, piece, from)
+	fBlackFrom := FeatureIndex(Black, color, piece, from)
+	fWhiteTo := FeatureIndex(White, color, piece, to)
+	fBlackTo := FeatureIndex(Black, color, piece, to)
+	pos.Acc.AddSub(pos.Net, fWhiteTo, fWhiteFrom, White)
+	pos.Acc.AddSub(pos.Net, fBlackTo, fBlackFrom, Black)
+}
+
+// CapturePiece relocates a piece from one square to another while capturing
+// an enemy piece on the destination square -- equivalent to RemovePiece(from)
+// + RemovePiece(to) + PutPiece(to, piece, color) but doing the NNUE
+// accumulator update as a single fused AddSubSub pass per perspective.
+func (pos *Position) CapturePiece(from, to Square, piece, color, capturedPiece uint8) {
+	theirColor := color ^ 1
+	fromBB := Bitboard(1 << from)
+	toBB := Bitboard(1 << to)
+
+	boardPieceFrom := pos.Board[from] // pre-adjustment, for the hash key
+	boardPieceTo := pos.Board[to]     // captured piece, pre-adjustment
+
+	pos.Pieces[color][piece] = pos.Pieces[color][piece]&^fromBB | toBB
+	pos.Pieces[theirColor][capturedPiece] &^= toBB
+	pos.Sides[color] = pos.Sides[color]&^fromBB | toBB
+	pos.Sides[theirColor] &^= toBB
+	pos.Blockers &^= fromBB // `to` stays occupied throughout
+
+	newBoardPieceTo := piece
+	if color == Black {
+		newBoardPieceTo += 10
+	}
+	pos.Board[from] = NoPiece
+	pos.Board[to] = newBoardPieceTo
+
+	pos.Hash ^= pieceSqKey(from, boardPieceFrom)
+	pos.Hash ^= pieceSqKey(to, boardPieceTo)
+	pos.Hash ^= pieceSqKey(to, newBoardPieceTo)
+
+	fWhiteFrom := FeatureIndex(White, color, piece, from)
+	fBlackFrom := FeatureIndex(Black, color, piece, from)
+	fWhiteTo := FeatureIndex(White, color, piece, to)
+	fBlackTo := FeatureIndex(Black, color, piece, to)
+	fWhiteCaptured := FeatureIndex(White, theirColor, capturedPiece, to)
+	fBlackCaptured := FeatureIndex(Black, theirColor, capturedPiece, to)
+
+	pos.Acc.AddSubSub(pos.Net, fWhiteTo, fWhiteFrom, fWhiteCaptured, White)
+	pos.Acc.AddSubSub(pos.Net, fBlackTo, fBlackFrom, fBlackCaptured, Black)
+}
+
+// UncapturePiece is the inverse of CapturePiece: it moves a piece from `to`
+// back to `from` and restores a previously-captured enemy piece on `to`,
+// fusing the accumulator update (AddAddSub) into one pass per perspective.
+func (pos *Position) UncapturePiece(from, to Square, piece, color, capturedPiece uint8) {
+	theirColor := color ^ 1
+	fromBB := Bitboard(1 << from)
+	toBB := Bitboard(1 << to)
+
+	boardPieceTo := pos.Board[to] // mover currently on `to`, pre-adjustment
+
+	pos.Pieces[color][piece] = pos.Pieces[color][piece]&^toBB | fromBB
+	pos.Pieces[theirColor][capturedPiece] |= toBB
+	pos.Sides[color] = pos.Sides[color]&^toBB | fromBB
+	pos.Sides[theirColor] |= toBB
+	pos.Blockers |= fromBB // `to` stays occupied throughout
+
+	newBoardPieceFrom := piece
+	if color == Black {
+		newBoardPieceFrom += 10
+	}
+	newBoardPieceTo := capturedPiece
+	if theirColor == Black {
+		newBoardPieceTo += 10
+	}
+	pos.Board[from] = newBoardPieceFrom
+	pos.Board[to] = newBoardPieceTo
+
+	pos.Hash ^= pieceSqKey(to, boardPieceTo)
+	pos.Hash ^= pieceSqKey(from, newBoardPieceFrom)
+	pos.Hash ^= pieceSqKey(to, newBoardPieceTo)
+
+	fWhiteFrom := FeatureIndex(White, color, piece, from)
+	fBlackFrom := FeatureIndex(Black, color, piece, from)
+	fWhiteTo := FeatureIndex(White, color, piece, to)
+	fBlackTo := FeatureIndex(Black, color, piece, to)
+	fWhiteCaptured := FeatureIndex(White, theirColor, capturedPiece, to)
+	fBlackCaptured := FeatureIndex(Black, theirColor, capturedPiece, to)
+
+	pos.Acc.AddAddSub(pos.Net, fWhiteFrom, fWhiteCaptured, fWhiteTo, White)
+	pos.Acc.AddAddSub(pos.Net, fBlackFrom, fBlackCaptured, fBlackTo, Black)
+}
+
 func (pos *Position) RemovePiece(sq Square) {
 	boardPiece := pos.Board[sq] // pre-adjustment (0-5 white, 10-15 black), for the hash key
 	piece := boardPiece
@@ -427,29 +540,29 @@ func (pos *Position) DoMove(move Move) {
 	}
 	pos.Hash ^= CastleKeys[pos.CastlingRights]
 
-	pos.RemovePiece(from)
-
 	if move.IsCastling() {
+		pos.RemovePiece(from)
 		rookFromSquare := RookSquares[move]
 		pos.RemovePiece(rookFromSquare)
 		rookToSquare := Square(int(to) - KingCastlingDirection(move))
 		pos.PutPiece(rookToSquare, Rook, ourColor)
 		pos.PutPiece(to, King, ourColor)
 	} else if move.IsEnPassant() {
+		pos.RemovePiece(from)
 		capturedPawnSq := Square(int(to) - PawnDisplacement(ourColor))
 		pos.RemovePiece(capturedPawnSq)
 		pos.PutPiece(to, movingPiece, ourColor)
 	} else if move.IsPromotion() {
+		pos.RemovePiece(from)
 		if capturedPiece != NoPiece { // is a capture
 			pos.RemovePiece(to)
 		}
 		pos.PutPiece(to, move.Promotion(), ourColor)
-	} else {
-		if capturedPiece != NoPiece { // is a capture
-			pos.RemovePiece(to)
-			pos.Rule50 = 0
-		}
-		pos.PutPiece(to, movingPiece, ourColor)
+	} else if capturedPiece != NoPiece { // is a capture: fuse remove(from)+remove(to)+put(to) into one accumulator pass
+		pos.Rule50 = 0
+		pos.CapturePiece(from, to, movingPiece, ourColor, capturedPiece)
+	} else { // plain quiet move: fuse remove(from)+put(to) into one accumulator pass
+		pos.MovePiece(from, to, movingPiece, ourColor)
 	}
 
 	pos.Ply++
@@ -477,27 +590,28 @@ func (pos *Position) UndoMove(move Move) {
 	pos.EnPassantSquare = lastState.EnPassantSquare
 	pos.Rule50 = lastState.Rule50
 
-	// put moved piece back to origin square
-	pos.PutPiece(from, lastState.MovedPiece, pos.Turn)
-
 	if move.IsEnPassant() {
+		pos.PutPiece(from, lastState.MovedPiece, pos.Turn) // put moved piece back to origin square
 		capturedPawnSq := Square(int(to) - PawnDisplacement(pos.Turn))
 		pos.RemovePiece(to)                            // remove capturer
 		pos.PutPiece(capturedPawnSq, Pawn, pos.Turn^1) // put captured pawn back
 	} else if move.IsCastling() {
+		pos.PutPiece(from, lastState.MovedPiece, pos.Turn) // put moved piece back to origin square
 		rookFromSquare := RookSquares[move]
 		rookToSquare := Square(int(to) - KingCastlingDirection(move))
 		pos.RemovePiece(rookToSquare)                // remove rook
 		pos.PutPiece(rookFromSquare, Rook, pos.Turn) // place rook
 		pos.RemovePiece(to)                          // remove king
 	} else if move.IsPromotion() {
-		pos.RemovePiece(to) // remove promoted piece
-	} else { // quiet move
-		pos.RemovePiece(to) // remove piece
-	}
-
-	if lastState.CapturedPiece != NoPiece { // capture
-		pos.PutPiece(to, lastState.CapturedPiece, pos.Turn^1) // put piece back
+		pos.PutPiece(from, lastState.MovedPiece, pos.Turn) // put moved piece back to origin square
+		pos.RemovePiece(to)                                // remove promoted piece
+		if lastState.CapturedPiece != NoPiece {            // capture
+			pos.PutPiece(to, lastState.CapturedPiece, pos.Turn^1) // put piece back
+		}
+	} else if lastState.CapturedPiece != NoPiece { // capture: fuse put(from)+remove(to)+put(to) into one accumulator pass
+		pos.UncapturePiece(from, to, lastState.MovedPiece, pos.Turn, lastState.CapturedPiece)
+	} else { // quiet move: fuse put(from)+remove(to) into one accumulator pass
+		pos.MovePiece(to, from, lastState.MovedPiece, pos.Turn)
 	}
 
 	// Overwrite rather than incrementally undo: the PutPiece/RemovePiece

--- a/engine/search.go
+++ b/engine/search.go
@@ -34,9 +34,18 @@ func mateInfo(score int32) (movesToMate int32, isMate bool) {
 	return movesToMate, true
 }
 
+const NodeReportInterval = 32768
+
 type Search struct {
 	Pos   Position
 	Nodes int
+
+	// lastReportedNodes is the Nodes value as of the last periodic
+	// unscored progress ping (see alphaBetaInner) -- a threshold-crossing
+	// check against this, rather than a Nodes%NodeReportInterval==0 check,
+	// so a ping is guaranteed at least every NodeReportInterval nodes
+	// regardless of exactly which node count a check happens to land on.
+	lastReportedNodes int
 
 	// limits
 	StartTime time.Time
@@ -384,7 +393,8 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 			alpha = score
 		}
 
-		if search.Nodes&32767 == 0 {
+		if search.Nodes-search.lastReportedNodes >= NodeReportInterval {
+			search.lastReportedNodes = search.Nodes
 			// No score here: bestScore is this internal node's own
 			// negamax-local value, not the root-relative evaluation UCI's
 			// `score` field is supposed to report -- nodes/depth are the

--- a/engine/search_test.go
+++ b/engine/search_test.go
@@ -414,7 +414,7 @@ func TestUciInfoReportsScoreOncePerDepth(t *testing.T) {
 		t.Errorf("last scored info line score = %d, want %d (Search()'s returned score)", lastScore, finalScore)
 	}
 	if !sawUnscoredPing {
-		t.Errorf("expected at least one unscored internal-node progress ping (search.Nodes should exceed 32767 at this depth)")
+		t.Errorf("expected at least one unscored internal-node progress ping (search.Nodes should exceed engine.NodeReportInterval at this depth)")
 	}
 }
 

--- a/tools/perft_bench.go
+++ b/tools/perft_bench.go
@@ -1,0 +1,20 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"silverfish/engine"
+)
+
+func main() {
+	engine.Init()
+	pos := engine.StartingPosition()
+	depth := 6
+	start := time.Now()
+	nodes := engine.Perft(&pos, depth, false)
+	elapsed := time.Since(start)
+	fmt.Printf("depth=%d nodes=%d elapsed=%s nps=%.0f\n", depth, nodes, elapsed, float64(nodes)/elapsed.Seconds())
+}


### PR DESCRIPTION
## Summary

Speeds up the NNUE incremental accumulator update path, which is the dominant cost of `DoMove`/`UndoMove` (perft with NNUE updates enabled was used as the benchmark, per discussion in this PR's originating conversation -- it's a good proxy for accumulator-update cost specifically, decoupled from search/pruning logic).

- **Fused accumulator updates.** `DoMove`/`UndoMove` previously updated the accumulator via separate full `Add`/`Remove` passes per piece touched (e.g. a quiet move did a full `Remove` pass then a full `Add` pass -- two full sweeps over the accumulator). Added `AddSub` (quiet moves), `AddSubSub` (captures), and `AddAddSub` (undoing captures), each combining the relevant add/sub terms into a single pass per perspective. Wired in via new `Position.MovePiece`/`CapturePiece`/`UncapturePiece` helpers, used by `DoMove`/`UndoMove` for the common-case (quiet move / plain capture) branches. Castling, en passant, and promotion are untouched, still using the original `RemovePiece`/`PutPiece` path (rare enough not to be worth the added complexity).
- **Flattened `Network.FeatureCols`** from `[][]float32` to a single contiguous `[]float32` (via a `featureCol(f)` slicing helper), removing a pointer indirection and improving cache locality on every column access.

## Results

`perft(startpos, depth 6, 119,060,324 nodes)`, measured after each change in isolation before combining:

| Step | nps | Δ vs previous |
|---|---|---|
| Baseline | 552,544 | -- |
| + AddSub fusion (quiet moves) | 766,488 | +38.7% |
| + flat `FeatureCols` | 823,884 | +7.5% |
| + AddSubSub/AddAddSub fusion (captures) | ~810,000 | ~flat (noise) |

Combined: **~47-49% faster** on this benchmark. The captures fusion doesn't move perft's number much (captures are a small fraction of the move list even in tactical positions like kiwipete, so the savings get diluted across the branching factor) but should matter more where captures dominate node *visits* rather than the move *list* -- i.e. `Quiescence` during real search.

Direct engine-vs-engine speed comparison (Stockfish 17 vs this branch, single-threaded, from a tactical middlegame FEN, fixed depth 5): Stockfish's own raw nps was only ~2.6x Silverfish's search nps in this sample -- the throughput gap between the two engines is real but modest; see "Why the SPRT is flat" below for why this matters.

## SPRT

Ran `after` (this branch) vs `before` (pre-change master-equivalent) on orca, `tc=15+0.15`, `elo0=0/elo1=10`, stopped manually after it plateaued rather than running to a full stopping bound:

```
Results of after vs before (15+0.15, NULL, NULL, 8moves_v3.pgn):
Elo: -3.42 +/- 11.77, nElo: -4.40 +/- 15.11
LOS: 28.42 %, DrawRatio: 47.98 %, PairsRatio: 0.94
Games: 2030, Wins: 811, Losses: 831, Draws: 388, Points: 1005.0 (49.51 %)
Ptnml(0-2): [119, 153, 487, 141, 115], WL/DD Ratio: 9.36
LLR: -1.58 (-53.7%) (-2.94, 2.94) [0.00, 10.00]
```

**Inconclusive/flat** -- LLR never approached either bound in 2,030 games, score 49.51%. This is expected, not a red flag: separately in this branch's originating conversation we established (via direct node-count comparison against Stockfish) that this engine's search depth is bottlenecked almost entirely by pruning/move-ordering quality (missing killer moves, history heuristic, null-move pruning, LMR -- see follow-up work), not raw node throughput. Under a high effective branching factor (~15-20, absent those techniques), a ~47% larger node budget only buys a small fraction of an additional ply (`ln(1.47)/ln(15) ≈ 0.14 ply`), which is well within the noise of a few-thousand-game SPRT. The speedup is expected to compound in value once pruning work lands and branching factor drops (the same node-budget increase buys proportionally more ply at a lower branching factor).

Kept the changes despite the flat SPRT: this is a pure arithmetic refactor of an already-tested code path (perft node counts are bit-identical before/after, full test suite green throughout), with no evidence of a directional regression (score sits at ~49.5%, not trending away from 50%) -- only reordered floating-point terms, which can shift float32 rounding at the ULP level but shouldn't and doesn't appear to introduce systematic bias.

## Also found (tracked separately, not fixed here)

While benchmarking with `go movetime`, discovered the engine can hang well past its requested movetime: `Search()`'s time check only fires between root moves, and `alphaBetaInner` has no internal time check at all, while `go movetime` sets an unbounded `MaxDepth`. Filed as a follow-up task, not part of this PR's scope.

## Out of scope / follow-ups

- Quantized (int8/int16) weights + SIMD -- the next tier of NNUE speedup, but a much larger project (network requantization, overflow-safe integer accumulation, likely hand-written SIMD).
- Fusing castling/EP/promotion accumulator updates (rare enough not to matter much).
- Search time-limit cancellation bug noted above.
- Killer moves / history heuristic / null-move pruning / LMR -- the actual next lever for engine strength, per the depth-gap analysis in this PR's originating conversation.