### PR TITLE
fix(uci): stop stdin-EOF spin loop and quit-vs-active-goroutine race

### DIFF
--- a/cmd/silverfish/main.go
+++ b/cmd/silverfish/main.go
@@ -108,8 +108,11 @@ mainloop:
 			if active {
 				// A search goroutine is running. Only quit is handled here;
 				// everything else (including stop) is dropped, since Search
-				// has no cancellation mechanism yet.
+				// has no cancellation mechanism yet. Wait for the goroutine
+				// to actually finish (and print its result) before exiting,
+				// rather than tearing down the process out from under it.
 				if message.MessageType == engine.UciQuitClientMessage {
+					<-actionAlertChannel
 					break mainloop
 				}
 				continue

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -115,6 +115,14 @@ func uciProcessGoMessage(message string) UciGoMessage {
 			result.Infinite = true
 		case "perft":
 			result.Perft = true
+			// Accept "go perft N" as shorthand for "go perft depth N":
+			// if the next token is a bare integer (not a recognized
+			// keyword), treat it as the depth.
+			if i+1 < len(tokens) {
+				if depth, err := strconv.Atoi(tokens[i+1]); err == nil {
+					result.Depth = int16(depth)
+				}
+			}
 		case "depth":
 			if depth, ok := intArg(i); ok {
 				result.Depth = int16(depth)
@@ -150,7 +158,10 @@ func UciProcessClientMessage(stdin *bufio.Scanner) UciClientMessage {
 
 	result := stdin.Scan()
 	if !result {
-		UciError("I/O error or something.")
+		// EOF (or a real read error) means there is no more input to read.
+		// Treat it as a quit so callers stop looping instead of spinning on
+		// a Scan() that will keep returning false forever.
+		message.MessageType = UciQuitClientMessage
 		return message
 	}
 


### PR DESCRIPTION
Three UCI-layer bugs found while trying to benchmark perft via a file-redirected UCI session (which looked like a 40-90 minute performance regression but wasn't): the EOF spin loop, the quit-vs-active-goroutine race, and `go perft N` silently not running perft.

## Why these three together

They compound: EOF now needs to behave like `quit` (fix 1), which meant `quit` arriving mid-search needed to actually wait for that search to finish rather than tearing the process down (fix 2) — fixing one exposed the other. Fix 3 (`go perft N` shorthand) is unrelated in mechanism but is what caused the specific symptom that led here: every perft script this session, mine included, had been sending the invalid bare form, which silently fell through to a normal unbounded search instead of erroring.

## Out of scope
The deeper "no internal time-check in `alphaBetaInner`, so `go movetime` can hang far past budget" issue is tracked separately (todo #6) — this only fixes the quit/EOF handling around it, not search cancellation itself.