### PR TITLE
late move reductions

### DIFF
--- a/engine/search.go
+++ b/engine/search.go
@@ -368,17 +368,48 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 		return search.Quiescence(alpha, beta, 0, ply)
 	}
 
+	inCheck := search.Pos.Checkers(search.Pos.Turn) != 0
+
 	bestScore := -Infinity
 	var bestMove Move
+	legalMoveNum := 0
 	for i := uint8(0); i < moveList.Count; i++ {
 		move := moveList.Moves[i]
 		if !search.Pos.MoveIsLegal(move) {
 			continue
 		}
 		hasLegal = true
+		legalMoveNum++
+
+		// Late Move Reductions: search moves that are unlikely to matter --
+		// late in the (MVV-LVA-then-TT-move) ordering, quiet (score 0: no
+		// killer/history heuristic yet to distinguish quiets further),
+		// not a promotion, and not while in check -- at reduced depth
+		// first. If a reduced search still beats alpha, it wasn't
+		// obviously bad, so re-search it at full depth before trusting the
+		// score. LeafMoveNum/depth thresholds are conservative (no PVS or
+		// killer/history yet to lean on for ordering confidence).
+		reduction := 0
+		if depth >= 3 && legalMoveNum > 3 && !inCheck && move.Score() == 0 && !move.IsPromotion() {
+			reduction = 1
+			if legalMoveNum > 6 {
+				reduction = 2
+			}
+			if reduction > depth-1 {
+				reduction = depth - 1
+			}
+		}
 
 		search.Pos.DoMove(move)
-		score := -search.alphaBetaInner(-beta, -alpha, depth-1, ply+1)
+		var score int32
+		if reduction > 0 {
+			score = -search.alphaBetaInner(-alpha-1, -alpha, depth-1-reduction, ply+1)
+			if score > alpha {
+				score = -search.alphaBetaInner(-beta, -alpha, depth-1, ply+1)
+			}
+		} else {
+			score = -search.alphaBetaInner(-beta, -alpha, depth-1, ply+1)
+		}
 		search.Pos.UndoMove(move)
 
 		if score >= beta {


### PR DESCRIPTION
Adds late move reductions (LMR) to `alphaBetaInner`: quiet, non-promotion moves searched late in a node's move list get reduced depth first, with a full-depth re-search if they beat alpha.

## Why the thresholds are conservative

No killer moves or history heuristic yet, so "quiet" is approximated as MVV-LVA score == 0 (no captured piece) -- a much cruder ordering signal than a real killer/history table would give. Reduction only kicks in at depth >= 3 and legalMoveNum > 3, and any reduced move that beats alpha gets re-searched at full depth before its score is trusted. That re-search is the safety net that makes the coarse "quiet" heuristic acceptable: a misordered quiet move only costs extra nodes, never a wrong score.

Promotions and in-check nodes are excluded from reduction entirely -- both are exactly the class of "quiet-looking but not actually quiet" move this coarse ordering can't otherwise distinguish.

## SPRT (orca, tc=10+0.1, elo0=0/elo1=10)

H1 accepted after 696/800 games:
```
Elo: 47.21 +/- 21.23, nElo: 58.19 +/- 25.81
LOS: 100.00%, Score: 56.75% (329W-235L-132D)
LLR: 2.99 (crossed the 2.94 bound)
```

19 games (2.7%) ended abandoned/time-forfeit, split ~evenly between both engines (lmr: 9, baseline: 10) -- traced to the pre-existing search-cancellation gap (todo #6: no internal time check in `alphaBetaInner`), not anything LMR-specific.