### PR TITLE
null-move pruning

### DIFF
--- a/engine/position.go
+++ b/engine/position.go
@@ -571,6 +571,27 @@ func (pos *Position) DoMove(move Move) {
 	pos.History = append(pos.History, state)
 }
 
+// DoNullMove passes the turn without moving a piece (used by null-move
+// pruning). Returns the previous en-passant square, to be passed to
+// UndoNullMove. Unlike DoMove, this doesn't push onto pos.History -- the
+// caller is expected to restore state itself via UndoNullMove rather than
+// via UndoMove/IsRepetition machinery.
+func (pos *Position) DoNullMove() Square {
+	prevEP := pos.EnPassantSquare
+	pos.Hash ^= enPassantKey(pos.EnPassantSquare)
+	pos.EnPassantSquare = NoSquare
+	pos.Turn ^= 1
+	pos.Hash ^= TurnKey
+	return prevEP
+}
+
+func (pos *Position) UndoNullMove(prevEP Square) {
+	pos.Turn ^= 1
+	pos.Hash ^= TurnKey
+	pos.EnPassantSquare = prevEP
+	pos.Hash ^= enPassantKey(pos.EnPassantSquare)
+}
+
 func (pos *Position) UndoMove(move Move) {
 	from := move.From()
 	to := move.To()

--- a/engine/search.go
+++ b/engine/search.go
@@ -313,6 +313,15 @@ func (search *Search) Quiescence(alpha, beta int32, qdepth int, ply int) int32 {
 	return alpha
 }
 
+// hasNonPawnMaterial reports whether color has any knight/bishop/rook/queen
+// on the board. Used to guard null-move pruning against zugzwang: in bare
+// king-and-pawn endgames, passing can be strictly better than any legal
+// move, which breaks the "a free move can only help our opponent" assumption
+// null-move pruning relies on.
+func hasNonPawnMaterial(pos *Position, color uint8) bool {
+	return pos.Pieces[color][Knight]|pos.Pieces[color][Bishop]|pos.Pieces[color][Rook]|pos.Pieces[color][Queen] != 0
+}
+
 // ply is the number of plies from the root of this search (the move passed
 // to alphaBetaInner from Search() is ply 1). Used only to prefer faster
 // mates (and defer forced ones): a mate found at a smaller ply scores
@@ -345,6 +354,28 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 		}
 	}
 
+	inCheckEarly := search.Pos.Checkers(search.Pos.Turn) != 0
+
+	// Null-move pruning: let the opponent move twice in a row (i.e. we do
+	// nothing) and search at reduced depth. If even a free move for the
+	// opponent can't bring the score down to beta, our actual move surely
+	// won't either, so prune. Guarded against zugzwang (positions where
+	// passing is actually better than any legal move, breaking the "a free
+	// move can only help" assumption -- mainly king-and-pawn endgames) by
+	// requiring the side to move to have some non-pawn material, and
+	// skipped in check (a null move can't escape check, so the reduced
+	// search would be meaningless) and near mate scores (verifying a mate
+	// score off a reduced, unverified search is unreliable).
+	if depth >= 3 && !inCheckEarly && beta < MateScoreThreshold && hasNonPawnMaterial(&search.Pos, search.Pos.Turn) {
+		const nullMoveReduction = 2
+		prevEP := search.Pos.DoNullMove()
+		score := -search.alphaBetaInner(-beta, -beta+1, depth-1-nullMoveReduction, ply+1)
+		search.Pos.UndoNullMove(prevEP)
+		if score >= beta {
+			return score
+		}
+	}
+
 	moveList := GenMoves(&search.Pos, BB_Full)
 
 	ScoreMoves(&search.Pos, &moveList)
@@ -354,7 +385,7 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 	hasLegal := false
 
 	if moveList.Count == 0 {
-		if search.Pos.Checkers(search.Pos.Turn) != 0 {
+		if inCheckEarly {
 			// checkmate
 			return -(Infinity - int32(ply))
 		} else {
@@ -368,7 +399,7 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 		return search.Quiescence(alpha, beta, 0, ply)
 	}
 
-	inCheck := search.Pos.Checkers(search.Pos.Turn) != 0
+	inCheck := inCheckEarly
 
 	bestScore := -Infinity
 	var bestMove Move


### PR DESCRIPTION
Adds null-move pruning to `alphaBetaInner`: give the opponent a free move and search at reduced depth (R=2); if that still fails high against beta, no real move here needs full-depth searching either.

## Why the zugzwang guard is structured this way

Null-move pruning's core assumption -- "passing can only help our opponent, never us" -- breaks in zugzwang, most commonly bare king-and-pawn endgames where any move (including a null one) weakens the position. Rather than a full zugzwang detector, this guards on a cheap proxy: skip NMP unless the side to move has at least one knight/bishop/rook/queen. That's the standard, well-tested heuristic (pawn/king-only endgames are essentially the only zugzwang-prone case in practice) and avoids the cost/complexity of anything more precise.

Also skipped in check (a null move can't escape check, so the reduced search is meaningless) and when beta is within `MateScoreThreshold` (a reduced, unverified search shouldn't be trusted to confirm a mate score).

## SPRT results

`nmp` vs `master` baseline, 10+0.1, elo0=0/elo1=10, concurrency 8, `8moves_v3.pgn` book:

```
Elo: 36.58 +/- 19.01, nElo: 42.17 +/- 21.73
LOS: 99.99 %, DrawRatio: 40.94 %
Games: 982, Wins: 460, Losses: 357, Draws: 165, Points: 542.5 (55.24 %)
LLR: 2.96 (100.6%) (-2.94, 2.94) [0.00, 10.00]
SPRT ([0.00, 10.00]) completed - H1 was accepted
```