### PR TITLE
feat(search): add killer moves and history heuristic

### DIFF
--- a/engine/search.go
+++ b/engine/search.go
@@ -194,23 +194,25 @@ func ScoreMoves(pos *Position, moveList *MoveList) {
 }
 
 // swap the highest score move to the front, leaving everything else untouched
+// OrderMoves sorts moveList by score descending (insertion sort: move lists
+// here are small -- at most a few dozen moves -- so this is cheap and
+// needs no allocation). A full sort, not just a best-to-front swap, matters
+// once ordering has more than one signal below the very top: MVV-LVA always
+// outranks killers/history (see maxQuietScore), so a swap-only pass could
+// only ever place a killer/history-favored quiet first in capture-free
+// positions, and even then left every other move in raw movegen order --
+// making killer/history scores irrelevant to move 2 onward, including to
+// which moves LMR treats as "late".
 func OrderMoves(pos *Position, moveList *MoveList) {
-	if moveList.Count <= 1 {
-		return
-	}
-
-	bestIdx := 0
-	bestScore := moveList.Moves[0].Score()
-
-	for j := 1; j < int(moveList.Count); j++ {
-		if moveList.Moves[j].Score() > bestScore {
-			bestIdx = j
-			bestScore = moveList.Moves[j].Score()
+	for i := 1; i < int(moveList.Count); i++ {
+		move := moveList.Moves[i]
+		score := move.Score()
+		j := i - 1
+		for j >= 0 && moveList.Moves[j].Score() < score {
+			moveList.Moves[j+1] = moveList.Moves[j]
+			j--
 		}
-	}
-
-	if bestIdx != 0 {
-		moveList.Moves[0], moveList.Moves[bestIdx] = moveList.Moves[bestIdx], moveList.Moves[0]
+		moveList.Moves[j+1] = move
 	}
 }
 

--- a/engine/search.go
+++ b/engine/search.go
@@ -36,6 +36,12 @@ func mateInfo(score int32) (movesToMate int32, isMate bool) {
 
 const NodeReportInterval = 32768
 
+// MaxKillerPly bounds the killers/history-indexed ply depth. Search depth is
+// user-controllable (`go depth N`), so this is a defensive cap, not an
+// expected real depth -- ply beyond it just skips killer lookups/stores
+// rather than growing the table unboundedly.
+const MaxKillerPly = 128
+
 type Search struct {
 	Pos   Position
 	Nodes int
@@ -47,10 +53,102 @@ type Search struct {
 	// regardless of exactly which node count a check happens to land on.
 	lastReportedNodes int
 
+	// killers holds up to 2 quiet moves per ply that have caused a beta
+	// cutoff there before, tried before other quiets on the assumption
+	// that a move good enough to cut off once at this ply is often good
+	// again in a sibling node (same ply, different path to it). Stored
+	// masked to their low 16 bits (see orderMoveFirst) since a Move's
+	// score field is mutable and irrelevant for identity comparison.
+	killers [MaxKillerPly][2]Move
+
+	// history accumulates a [side][from][to] weight on every quiet-move
+	// beta cutoff, weighted by depth^2 so cutoffs found deeper (more
+	// searched-out, so more reliable) count for more. Orders quiet moves
+	// that aren't killers at this ply. Unlike killers this isn't
+	// ply-indexed -- it's a search-wide "this from/to square pair tends to
+	// be strong" signal, not a "strong at this specific ply" one.
+	history [2][64][64]int32
+
 	// limits
 	StartTime time.Time
 	TimeLimit time.Duration
 	MaxDepth  int
+}
+
+// isQuietMove reports whether move is neither a capture nor a promotion.
+// Must be called with pos in the state move would be played from (i.e.
+// before DoMove, or after the matching UndoMove) -- it inspects the
+// pre-move board to find move's victim, if any. En passant's victim isn't
+// on move's own To() square, so it's special-cased directly.
+func isQuietMove(pos *Position, move Move) bool {
+	if move.IsPromotion() || move.IsEnPassant() {
+		return false
+	}
+	_, victim := pos.GetSquare(move.To())
+	return victim == NoPiece
+}
+
+// recordKiller stores move as the newest killer at ply, keeping the
+// previous killers[ply][0] as the second slot (so the two most recent
+// distinct cutoff moves at this ply are remembered). A no-op if move is
+// already the top killer here, to avoid the two slots collapsing to
+// duplicates of the same move.
+func (search *Search) recordKiller(move Move, ply int) {
+	if ply >= MaxKillerPly {
+		return
+	}
+	m := move & 0xffff
+	if search.killers[ply][0]&0xffff == m {
+		return
+	}
+	search.killers[ply][1] = search.killers[ply][0]
+	search.killers[ply][0] = m
+}
+
+// recordHistory increments the history weight for a quiet move that caused
+// a beta cutoff, by depth^2. Deliberately unbounded/unclamped here --
+// scoreQuiets clamps at read time (a move's score field is only 16 bits, so
+// the raw accumulator must never be written into it directly).
+func (search *Search) recordHistory(move Move, depth int) {
+	search.history[search.Pos.Turn][move.From()][move.To()] += int32(depth * depth)
+}
+
+// maxQuietScore is the highest score scoreQuiets ever assigns, kept below
+// MvvLva's lowest nonzero entry (10) so a killer or history-favored quiet
+// can never be ordered ahead of an actual capture.
+const maxQuietScore = 9
+
+// scoreQuiets scores every not-yet-scored (quiet) move in moveList using
+// search's killers and history tables, leaving moves ScoreMoves already
+// scored (captures/promotions, all nonzero) untouched. Killers at this ply
+// take the top two quiet scores; everything else gets a history-derived
+// score clamped to fit below them.
+func (search *Search) scoreQuiets(moveList *MoveList, ply int) {
+	var killer1, killer2 Move
+	if ply < MaxKillerPly {
+		killer1, killer2 = search.killers[ply][0], search.killers[ply][1]
+	}
+
+	for i := 0; i < int(moveList.Count); i++ {
+		move := &moveList.Moves[i]
+		if move.Score() != 0 {
+			continue
+		}
+
+		masked := *move & 0xffff
+		switch {
+		case killer1 != 0 && masked == killer1:
+			move.GiveScore(maxQuietScore)
+		case killer2 != 0 && masked == killer2:
+			move.GiveScore(maxQuietScore - 1)
+		default:
+			h := search.history[search.Pos.Turn][move.From()][move.To()]
+			if h > maxQuietScore-2 {
+				h = maxQuietScore - 2
+			}
+			move.GiveScore(int(h))
+		}
+	}
 }
 
 // return number in milliseconds
@@ -379,6 +477,7 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 	moveList := GenMoves(&search.Pos, BB_Full)
 
 	ScoreMoves(&search.Pos, &moveList)
+	search.scoreQuiets(&moveList, ply)
 	OrderMoves(&search.Pos, &moveList)
 	orderMoveFirst(&moveList, ttMove)
 
@@ -413,15 +512,14 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 		legalMoveNum++
 
 		// Late Move Reductions: search moves that are unlikely to matter --
-		// late in the (MVV-LVA-then-TT-move) ordering, quiet (score 0: no
-		// killer/history heuristic yet to distinguish quiets further),
-		// not a promotion, and not while in check -- at reduced depth
-		// first. If a reduced search still beats alpha, it wasn't
-		// obviously bad, so re-search it at full depth before trusting the
-		// score. LeafMoveNum/depth thresholds are conservative (no PVS or
-		// killer/history yet to lean on for ordering confidence).
+		// late in the (MVV-LVA/killer/history-then-TT-move) ordering, quiet,
+		// and not while in check -- at reduced depth first. If a reduced
+		// search still beats alpha, it wasn't obviously bad, so re-search it
+		// at full depth before trusting the score. LeafMoveNum/depth
+		// thresholds are conservative (no PVS yet to lean on for ordering
+		// confidence).
 		reduction := 0
-		if depth >= 3 && legalMoveNum > 3 && !inCheck && move.Score() == 0 && !move.IsPromotion() {
+		if depth >= 3 && legalMoveNum > 3 && !inCheck && isQuietMove(&search.Pos, move) {
 			reduction = 1
 			if legalMoveNum > 6 {
 				reduction = 2
@@ -445,6 +543,10 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 
 		if score >= beta {
 			TTStore(search.Pos.Hash, move, ScoreToTT(score, ply), depth, BoundLower)
+			if isQuietMove(&search.Pos, move) {
+				search.recordKiller(move, ply)
+				search.recordHistory(move, depth)
+			}
 			return score
 		}
 		if score > bestScore {

--- a/engine/search_test.go
+++ b/engine/search_test.go
@@ -372,7 +372,11 @@ func TestSearchCapturesHangingPiece(t *testing.T) {
 func TestUciInfoReportsScoreOncePerDepth(t *testing.T) {
 	fen := "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"
 	pos := engine.FromFEN(fen)
-	search := engine.Search{MaxDepth: 4, TimeLimit: engine.InfiniteMovetime}
+	// Depth chosen to comfortably exceed NodeReportInterval so the
+	// unscored-ping assertion below is meaningful -- move ordering
+	// improvements (full-sort OrderMoves, killers/history) make a given
+	// depth cheaper over time, so this may need bumping again later.
+	search := engine.Search{MaxDepth: 6, TimeLimit: engine.InfiniteMovetime}
 	search.Init(&pos)
 
 	var finalScore int32
@@ -407,8 +411,8 @@ func TestUciInfoReportsScoreOncePerDepth(t *testing.T) {
 			t.Errorf("depth %d: got %d scored info lines, want exactly 1", d, count)
 		}
 	}
-	if lastDepth != 4 {
-		t.Errorf("last scored info line was depth %d, want 4 (MaxDepth)", lastDepth)
+	if lastDepth != 6 {
+		t.Errorf("last scored info line was depth %d, want 6 (MaxDepth)", lastDepth)
 	}
 	if lastScore != finalScore {
 		t.Errorf("last scored info line score = %d, want %d (Search()'s returned score)", lastScore, finalScore)


### PR DESCRIPTION
Orders quiet moves by two signals instead of leaving them all unranked at score 0: up to 2 killer moves per ply (quiets that caused a beta cutoff there before), then a `[side][from][to]` history table incremented by depth² on quiet cutoffs.

## Why quiets are scored 0-9

Kept strictly below `MvvLva`'s lowest nonzero entry (10) so a killer/history-favored quiet can never outrank an actual capture -- this only sharpens ordering among quiets, it doesn't touch capture ordering.

## The OrderMoves bug this uncovered

The first SPRT attempt on this branch was flat (Elo -4.78 +/- 20.07, LLR -0.71 over 800 games). Cause: `OrderMoves` only ever swapped the single best-scored move to the front, leaving everything else in raw movegen order. Since MVV-LVA always outranks killer/history scores, that swap could only place a killer/history-favored quiet first in capture-free positions -- and even then, ordering among the remaining moves (which LMR also uses to decide what's "late") was untouched.

Fixed by making `OrderMoves` a real sort (cheap here -- move lists are small, insertion sort, no allocation). This isn't specific to killers/history: it was silently weakening ordering for every prior feature that leans on move scores beyond the very first move, which is why the effect size below is much larger than a killer/history addition alone would produce.

## SPRT results

`kh` (killers/history + OrderMoves fix) vs `master` baseline, 10+0.1, elo0=0/elo1=10, concurrency 8, `8moves_v3.pgn` book:

```
Elo: 235.45 +/- 52.17, nElo: 294.71 +/- 48.15
LOS: 100.00 %, DrawRatio: 20.00 %
Games: 200, Wins: 140, Losses: 22, Draws: 38, Points: 159.0 (79.50 %)
LLR: 2.95 (100.1%) (-2.94, 2.94) [0.00, 10.00]
SPRT ([0.00, 10.00]) completed - H1 was accepted
```

(A pre-fix attempt with the swap-only `OrderMoves` finished flat/negative at 800 games -- Elo -4.78 +/- 20.07, LLR -0.71 -- which is what surfaced the bug.)