### PR TITLE
fix(uci): signal search completion before printing bestmove

### DIFF
--- a/cmd/silverfish/main.go
+++ b/cmd/silverfish/main.go
@@ -33,10 +33,12 @@ func executeGoCommand(channel chan bool, position *engine.Position, command *eng
 	if command.Perft && command.Depth != 0 {
 		engine.UciLog("Perft started.")
 		result := engine.Perft(position, int(command.Depth), true)
-		engine.UciLog(fmt.Sprintf("Perft result: %d", result))
-
-		// Tell the main thread that we're done.
+		// Signal completion before logging: the main loop drops any
+		// message that arrives while `active` is still true, so a fast
+		// client sending its next command right after seeing output on
+		// stdout must never be able to race ahead of this.
 		channel <- true
+		engine.UciLog(fmt.Sprintf("Perft result: %d", result))
 		return
 	}
 
@@ -64,9 +66,15 @@ func executeGoCommand(channel chan bool, position *engine.Position, command *eng
 	var bestMove engine.Move
 	_, bestMove = search.Search()
 
-	engine.UciBestMove(bestMove)
-
+	// Signal completion (clearing `active` in the main loop) before
+	// printing bestmove -- see the comment above in the perft branch. A
+	// client that reacts to "bestmove" on stdout by immediately sending
+	// its next command must never be able to race ahead of `active`
+	// being reset, or that next command (including the next "go") gets
+	// silently dropped and the engine hangs waiting for a command that
+	// will never come.
 	channel <- true
+	engine.UciBestMove(bestMove)
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- \`executeGoCommand\` printed \`bestmove\`/logged perft results before signaling \`actionAlertChannel\`, so a fast client reacting to that output could send its next command (including the next \`go\`) while the main loop's \`active\` flag was still true — and the main loop silently drops all non-quit messages while \`active\`. That drops the next \`go\` and hangs the engine forever waiting for a command that already arrived and was discarded.
- Found via \`training/selfplay_label.py\`, which drives one long-lived engine process through thousands of rapid \`ucinewgame\`/\`position\`/\`go\` cycles — exactly the pattern that exposes the race. Reproduced within ~100-300 cycles.
- Fix: signal completion before writing any output, so a fast client can never observe output before \`active\` is reset.

## Test plan
- [x] \`go build\`, \`go vet\`, \`go test ./engine\`
- [x] \`make perft\` — all positions pass
- [x] 300 rapid ucinewgame/position/go cycles against one process — no hang (previously failed within ~100-300 cycles)
- Not an SPRT candidate: pure UCI-protocol correctness fix, no move-selection/ordering change.