### PR TITLE
feat(see): add Static Exchange Evaluation

### DIFF
--- a/engine/see.go
+++ b/engine/see.go
@@ -1,0 +1,140 @@
+package engine
+
+// SeeValue is indexed by the same piece constants as MvvLva (Pawn..King).
+// Standard relative values, scaled to match centipawn-ish magnitudes used
+// elsewhere in the engine.
+var SeeValue = [7]int{100, 320, 330, 500, 900, 20000, 0}
+
+// see runs Static Exchange Evaluation for a capture on sq, simulating the
+// full exchange sequence (every attacker of both colors, cheapest piece
+// recapturing first, including X-ray attackers revealed as sliders are
+// removed) and returns the net material result for the side initiating
+// the capture. from/attacker is the specific moving piece/square (not
+// re-derived -- if two same-type pieces could both capture on sq, SEE must
+// evaluate the one actually being played, not an arbitrary substitute).
+// victim is the piece currently on sq. epCapturedBB is normally 0; for en
+// passant it's the bit of the actually-captured pawn's square, which is
+// not sq itself (sq is the empty destination square) -- it still needs to
+// come off the board before X-ray attackers are recomputed, or a slider
+// pinned behind that pawn would be missed.
+//
+// Standard swap-list algorithm (same shape as Stockfish's): O(number of
+// attackers), no recursion, no board mutation, no allocation -- cheap
+// enough to call once per capture during move ordering.
+// GetRookMoves/GetBishopMoves against a shrinking blocker bitboard is all
+// that's needed to reveal X-ray attackers behind a removed slider; DoMove
+// is never called.
+func (pos *Position) see(sq Square, from Square, attacker uint8, victim uint8, epCapturedBB Bitboard) int {
+	fromBB := Bitboard(1 << from)
+	occupied := pos.Blockers &^ fromBB &^ epCapturedBB
+	attackers := (pos.Attackers(sq) &^ fromBB) | pos.seeRevealedAttackers(sq, occupied, attacker)
+
+	var gain [32]int
+	depth := 0
+	gain[0] = SeeValue[victim]
+	nextVictim := attacker
+	side := pos.Turn ^ 1
+
+	for {
+		ourAttackers := attackers & pos.Sides[side] & occupied
+		if ourAttackers == 0 {
+			break
+		}
+
+		attackerSq, piece := pos.seeLeastValuableAttacker(ourAttackers, side)
+		depth++
+		gain[depth] = SeeValue[nextVictim] - gain[depth-1]
+
+		// Stand pat: if even winning this exchange can't beat what's
+		// already banked, neither side benefits from continuing --
+		// stop here rather than growing the (bounded) gain array
+		// further than necessary.
+		if max(-gain[depth-1], gain[depth]) < 0 {
+			break
+		}
+
+		attackerBB := Bitboard(1 << attackerSq)
+		occupied &^= attackerBB
+		attackers = (attackers &^ attackerBB) | pos.seeRevealedAttackers(sq, occupied, piece)
+
+		nextVictim = piece
+		side ^= 1
+	}
+
+	for depth > 0 {
+		gain[depth-1] = -max(-gain[depth-1], gain[depth])
+		depth--
+	}
+	return gain[0]
+}
+
+// seeLeastValuableAttacker picks the cheapest piece belonging to side in
+// the attackers bitboard, checked in ascending value order so pawns are
+// preferred over knights/bishops, etc.
+func (pos *Position) seeLeastValuableAttacker(attackers Bitboard, side uint8) (Square, uint8) {
+	for piece := Pawn; piece <= King; piece++ {
+		bb := attackers & pos.Pieces[side][piece]
+		if bb != 0 {
+			return Lsb(bb), piece
+		}
+	}
+	// Unreachable: attackers is always a subset of side's occupied
+	// squares, and every occupied square holds one of Pawn..King.
+	return Lsb(attackers), Pawn
+}
+
+// seeRevealedAttackers returns any new attackers of sq that were behind
+// the just-removed piece (X-ray sliders), restricted to still-occupied
+// squares. removedPiece skips the lookup for non-sliders (pawns/knights/
+// king can't reveal anything relevant here -- only rook/bishop/queen lines
+// matter), which is the most common case in a swap sequence, so worth
+// avoiding the extra magic lookups for.
+func (pos *Position) seeRevealedAttackers(sq Square, occupied Bitboard, removedPiece uint8) Bitboard {
+	if removedPiece == Knight || removedPiece == King {
+		return 0
+	}
+	orthogonal := GetRookMoves(sq, occupied)
+	diagonal := GetBishopMoves(sq, occupied)
+	var revealed Bitboard
+	revealed |= (pos.Pieces[White][Rook] | pos.Pieces[Black][Rook]) & orthogonal
+	revealed |= (pos.Pieces[White][Bishop] | pos.Pieces[Black][Bishop]) & diagonal
+	revealed |= (pos.Pieces[White][Queen] | pos.Pieces[Black][Queen]) & (orthogonal | diagonal)
+	return revealed & occupied
+}
+
+// SEE is the public entry point: net material result (from the moving
+// side's perspective) of playing move, assuming a full best-play exchange
+// sequence on move's target square. Non-captures always return 0 (nothing
+// to swap off). En passant is treated as capturing a pawn on the
+// destination square, which is accurate for SEE's purposes even though the
+// captured pawn isn't physically on that square.
+func SEE(pos *Position, move Move) int {
+	to := move.To()
+	_, attacker := pos.GetSquare(move.From())
+
+	var victim uint8
+	var epCapturedBB Bitboard
+	if move.IsEnPassant() {
+		victim = Pawn
+		// The captured pawn sits on the same rank as the mover's
+		// from-square and the same file as to -- not on to itself.
+		epRank := move.From() / 8
+		epCapturedBB = Bitboard(1 << (epRank*8 + to%8))
+	} else {
+		_, victim = pos.GetSquare(to)
+	}
+	if victim == NoPiece {
+		return 0
+	}
+
+	if move.IsPromotion() {
+		// Promotion changes the moving piece's value mid-exchange; the
+		// swap-list doesn't model that transition. Approximate by
+		// scoring the exchange as if the pawn were already the promoted
+		// piece -- good enough for ordering/pruning, not used for exact
+		// material accounting elsewhere.
+		attacker = move.Promotion()
+	}
+
+	return pos.see(to, move.From(), attacker, victim, epCapturedBB)
+}

--- a/engine/see_test.go
+++ b/engine/see_test.go
@@ -1,0 +1,86 @@
+package engine_test
+
+import (
+	"silverfish/engine"
+	"testing"
+)
+
+func TestSEE(t *testing.T) {
+	cases := []struct {
+		name string
+		fen  string
+		move string
+		want int
+	}{
+		{
+			// White queen takes a pawn defended by another black pawn:
+			// after Qxe5, the pawn on d6 recaptures. Losing exchange:
+			// +100 (pawn) then -900 (queen) = -800 net for white.
+			name: "queen takes pawn-defended pawn loses the queen",
+			fen:  "4k3/8/3p4/4p3/8/8/4Q3/4K3 w - - 0 1",
+			move: "e2e5",
+			want: 100 - 900,
+		},
+		{
+			// Knight takes a pawn with no black defenders at all --
+			// clean, undisputed win of a pawn.
+			name: "knight takes fully undefended pawn",
+			fen:  "4k3/8/8/4p3/8/3N4/8/4K3 w - - 0 1",
+			move: "d3e5",
+			want: 100,
+		},
+		{
+			// X-ray: white rook on e4 (front) takes the pawn on e5, then
+			// black's rook on e8 recaptures the white rook, then white's
+			// second rook on e1 -- invisible to a naive "just check
+			// direct attackers" scan, since e4's rook was in the way
+			// until it moved -- recaptures black's rook. Net for white:
+			// +100 (pawn) - 500 (first rook lost) + 500 (black rook won)
+			// = +100, a favorable exchange only visible with X-ray
+			// attackers accounted for.
+			name: "x-ray attacker behind the first rook wins the exchange",
+			fen:  "4r1k1/8/8/4p3/4R3/8/8/4R1K1 w - - 0 1",
+			move: "e4e5",
+			want: 100,
+		},
+		{
+			name: "en passant capture is a clean pawn win when undefended",
+			fen:  "4k3/8/8/8/3pP3/8/8/4K3 b - e3 0 1",
+			move: "d4e3",
+			want: 100,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pos := engine.FromFEN(c.fen)
+			// NewMoveFromStr can't know a move is en passant/castling
+			// from the UCI string alone (those flags come from movegen
+			// context) -- find the matching legal move instead, so it
+			// carries the right flags.
+			want := engine.NewMoveFromStr(c.move)
+			var move engine.Move
+			found := false
+			for _, m := range pos.LegalMoves() {
+				// Compare from/to squares only (bits 0-11) -- the flag
+				// bits (14-15: castling/en passant/promotion) live in
+				// this same low-16 range but NewMoveFromStr never sets
+				// them, so a full low-16 match would never find an en
+				// passant/castling move.
+				if m&0xfff == want&0xfff {
+					move = m
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("move %s not found among legal moves for %s", c.move, c.fen)
+			}
+
+			got := engine.SEE(&pos, move)
+			if got != c.want {
+				t.Errorf("SEE(%s, %s) = %d, want %d", c.fen, c.move, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Foundational SEE implementation, scoped as its own step per the search-improvement plan (SEE / futility / razoring / aspiration windows, roughly in that order). Standard bitboard swap-list algorithm — simulates the full capture exchange on a square, cheapest attacker recaptures each ply, X-ray attackers revealed as sliders are removed. O(number of attackers), no recursion, no `DoMove`/`UndoMove`, no allocation.

**Not wired into move ordering yet** — this PR has no strength effect on its own, so no SPRT. Wiring SEE into `ordering.go` (replacing/augmenting MVV-LVA for capture scoring) is the natural next step and will get its own SPRT, so a regression is attributable to one change at a time.

## Test plan
- [x] `go build`, `go vet`, `go test ./engine`
- [x] 4 hand-traced unit cases, cross-checked against `tools/chess_check.py` for move legality before asserting expected values: pawn-defended piece loss, fully undefended capture, an X-ray attacker behind the first rook (the case a naive direct-attackers-only scan gets wrong), and en passant (captured pawn isn't on the destination square, needed explicit handling for X-ray purposes)