### PR TITLE
feat(search): futility pruning

### DIFF
--- a/engine/search.go
+++ b/engine/search.go
@@ -392,6 +392,29 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 
 	inCheck := inCheckEarly
 
+	// Futility pruning: this close to the horizon, a quiet, non-check-giving
+	// move can only improve the position by a small amount -- if even the
+	// static eval plus a generous margin can't reach alpha, this branch is
+	// almost certainly not going to raise alpha either, so it's skipped
+	// entirely rather than searched. Margins are deliberately more
+	// conservative than a well-tuned modern engine would use (real engines
+	// go much smaller): this engine's move ordering is comparatively weak
+	// (no SEE, no PVS -- both tried and dropped this session after negative
+	// SPRTs), so an aggressive margin risks pruning away moves ordering
+	// hasn't actually ranked well. Gated off near mate scores (a
+	// material-margin argument says nothing reliable about a nearby forced
+	// mate) and never applied to a node's first move (that's move ordering's
+	// best guess, and always gets searched for real).
+	const futilityMaxDepth = 3
+	var futilityMargin = [futilityMaxDepth + 1]int32{0, 150, 300, 450}
+
+	canFutilityPrune := false
+	if depth >= 1 && depth <= futilityMaxDepth && !inCheck &&
+		alpha > -MateScoreThreshold && beta < MateScoreThreshold {
+		staticEval := Evaluate(&search.Pos)
+		canFutilityPrune = staticEval+futilityMargin[depth] <= alpha
+	}
+
 	bestScore := -Infinity
 	var bestMove Move
 	legalMoveNum := 0
@@ -403,6 +426,8 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 		hasLegal = true
 		legalMoveNum++
 
+		isQuiet := isQuietMove(&search.Pos, move)
+
 		// Late Move Reductions: search moves that are unlikely to matter --
 		// late in the (MVV-LVA/killer/history-then-TT-move) ordering, quiet,
 		// and not while in check -- at reduced depth first. If a reduced
@@ -411,7 +436,7 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 		// thresholds are conservative (no PVS yet to lean on for ordering
 		// confidence).
 		reduction := 0
-		if depth >= 3 && legalMoveNum > 3 && !inCheck && isQuietMove(&search.Pos, move) {
+		if depth >= 3 && legalMoveNum > 3 && !inCheck && isQuiet {
 			reduction = 1
 			if legalMoveNum > 6 {
 				reduction = 2
@@ -422,6 +447,17 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 		}
 
 		search.Pos.DoMove(move)
+
+		// The futility skip check needs the post-move position: a move
+		// that looks prunable by material margin alone must still be
+		// searched for real if it gives check (a checking "quiet" move can
+		// be tactically decisive despite costing no material).
+		if canFutilityPrune && legalMoveNum > 1 && isQuiet &&
+			search.Pos.Checkers(search.Pos.Turn) == 0 {
+			search.Pos.UndoMove(move)
+			continue
+		}
+
 		var score int32
 		if reduction > 0 {
 			score = -search.alphaBetaInner(-alpha-1, -alpha, depth-1-reduction, ply+1)


### PR DESCRIPTION
## Summary
Near the horizon (depth 1-3), a quiet, non-check-giving move is skipped if the static eval plus a margin still can't reach alpha -- such a move is very unlikely to raise alpha, so it's not worth spending a full search on. Never applied to a node's first move (always searched for real), when in check, or near mate scores.

Researched via chessprogramming.org, TalkChess, and a real reference implementation ([deanmchris/blunder](https://github.com/deanmchris/blunder), a Go engine whose actual search code was read directly) before implementing. Two deliberate departures from that reference, both erring conservative given this engine's move ordering is weaker (no SEE, no PVS -- both tried and dropped this session after negative SPRTs, see `todo.md`):
- Margins (150/300/450 for depth 1/2/3) are larger than the reference's tuned 100/160/220.
- Depth range capped at 3 (classical futility/extended-futility range) rather than the reference's depth-8 cutoff, which assumes a more mature search this engine doesn't have.

## Test plan
- [x] `go build`, `go vet`, `go test ./engine`
- [x] `make perft` -- all positions pass
- [x] Fixed-depth node counts lower across every one of 5 test positions (unlike the SEE/aspiration-window attempts' mixed results), with scores essentially unchanged (<=1cp difference) -- low search instability, as expected for a technique that shouldn't change which move is best, just how much work it takes to find it
- [x] SPRT vs master, three runs, consistently positive every time (never once negative), no single run formally crossed its LLR bound but the combined signal is strong:
  - elo0=0/elo1=5, 1600 games: +10.21 Elo (+/- 15.48), LOS 90.23%, LLR 0.58 (19.7% toward H1)
  - elo0=0/elo1=3, 3200 games: +15.43 Elo (+/- 10.50), LOS 99.80%, LLR 1.28 (43.6% toward H1)
  - elo0=0/elo1=3 continuation, 2000 games: +9.38 Elo (+/- 13.09), LOS 92.01%, LLR 0.47 (15.9% toward H1)