### PR TITLE
feat(search): Lazy SMP multi-threaded search

### DIFF
--- a/cmd/silverfish/main.go
+++ b/cmd/silverfish/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime/pprof"
 	"silverfish/engine"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -64,7 +65,7 @@ func executeGoCommand(channel chan bool, position *engine.Position, command *eng
 	search.Init(position)
 
 	var bestMove engine.Move
-	_, bestMove = search.Search()
+	_, bestMove = engine.SearchLazySMP(&search)
 
 	// Signal completion (clearing `active` in the main loop) before
 	// printing bestmove -- see the comment above in the perft branch. A
@@ -154,7 +155,21 @@ mainloop:
 }
 
 func handleSetOption(opt *engine.UciSetOptionMessage, position *engine.Position) {
-	if opt == nil || !strings.EqualFold(opt.Name, "EvalFile") {
+	if opt == nil {
+		return
+	}
+
+	if strings.EqualFold(opt.Name, "Threads") {
+		n, err := strconv.Atoi(opt.Value)
+		if err != nil || n < 1 {
+			engine.UciError(fmt.Sprintf("invalid Threads value %q", opt.Value))
+			return
+		}
+		engine.Threads = n
+		return
+	}
+
+	if !strings.EqualFold(opt.Name, "EvalFile") {
 		return
 	}
 

--- a/engine/search.go
+++ b/engine/search.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"sync/atomic"
 	"time"
 )
 
@@ -73,6 +74,24 @@ type Search struct {
 	// every frame on the way back up the call stack can bail out on a cheap
 	// field read instead of each re-checking time.Since.
 	timedOut bool
+
+	// stopSignal, if set (see SetStopSignal), is a shared cancellation flag
+	// used by Lazy SMP (smp.go): once the main search thread finishes, it
+	// flips this so any still-running helper threads unwind promptly rather
+	// than running out their own full time budget for no benefit.
+	stopSignal *int32
+
+	// silent suppresses UciInfo output. Set on Lazy SMP helper threads
+	// (smp.go) -- only the main thread's progress/PV is meaningful UCI
+	// output; helpers exist purely to enrich the shared TT.
+	silent bool
+}
+
+// SetStopSignal wires an external cancellation flag into checkTimeUp, in
+// addition to this Search's own time/depth budget. Used by Lazy SMP to stop
+// helper threads once the main thread concludes.
+func (search *Search) SetStopSignal(stop *int32) {
+	search.stopSignal = stop
 }
 
 // checkTimeUp reports whether the search has exceeded its time budget.
@@ -84,6 +103,10 @@ type Search struct {
 // still gets probed every couple thousand nodes no matter how deep it goes.
 func (search *Search) checkTimeUp() bool {
 	if search.timedOut {
+		return true
+	}
+	if search.stopSignal != nil && atomic.LoadInt32(search.stopSignal) != 0 {
+		search.timedOut = true
 		return true
 	}
 	if search.Nodes&2047 == 0 && time.Since(search.StartTime) > search.TimeLimit {
@@ -205,20 +228,22 @@ func (search *Search) Search() (int32, Move) {
 				// Reported once per completed depth, with that depth's own
 				// final score -- not per move, and not a stale score left
 				// over from the previous depth.
-				infoScore := bestScore
-				movesToMate, isMate := mateInfo(bestScore)
-				if isMate {
-					infoScore = movesToMate
+if !search.silent {
+					infoScore := bestScore
+					movesToMate, isMate := mateInfo(bestScore)
+					if isMate {
+						infoScore = movesToMate
+					}
+					UciInfo(UciInfoMessage{
+						depth:    depth,
+						hasDepth: true,
+						score:    infoScore,
+						hasScore: true,
+						isMate:   isMate,
+						nodes:    search.Nodes,
+						hasNodes: true,
+					})
 				}
-				UciInfo(UciInfoMessage{
-					depth:    depth,
-					hasDepth: true,
-					score:    infoScore,
-					hasScore: true,
-					isMate:   isMate,
-					nodes:    search.Nodes,
-					hasNodes: true,
-				})
 			}
 		}
 
@@ -490,7 +515,7 @@ func (search *Search) alphaBetaInner(alpha, beta int32, depth int, ply int) int3
 			alpha = score
 		}
 
-		if search.Nodes-search.lastReportedNodes >= NodeReportInterval {
+		if !search.silent && search.Nodes-search.lastReportedNodes >= NodeReportInterval {
 			search.lastReportedNodes = search.Nodes
 			// No score here: bestScore is this internal node's own
 			// negamax-local value, not the root-relative evaluation UCI's

--- a/engine/smp.go
+++ b/engine/smp.go
@@ -1,0 +1,65 @@
+package engine
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Threads is the number of search goroutines SearchLazySMP spawns (1 =
+// classic single-threaded search, no locking overhead anywhere -- see
+// ttSMPActive in tt.go). Set via the UCI "Threads" option, defaulting to 1
+// so existing single-threaded behavior is unchanged unless a GUI/tester
+// opts in.
+var Threads = 1
+
+// SearchLazySMP runs Threads-1 helper searches alongside a main search, all
+// against the same position and all sharing the package-level TT (see
+// tt.go). Helpers get no dedicated time check of their own beyond the
+// shared stop signal below -- they run the same iterative-deepening loop as
+// the main search and simply get interrupted once the main search
+// concludes.
+//
+// The result returned is always the main search's own best move/score:
+// helpers exist only to seed the shared TT with additional
+// depth/best-move/bound information (found via naturally-diverging
+// goroutine scheduling -- no explicit diversification of helper searches is
+// needed), not to be trusted for the final answer themselves. This is the
+// standard "Lazy SMP" design (as opposed to a proper split-point/YBWC
+// parallel search): dead simple, no work-stealing or synchronization beyond
+// the TT, and known to scale sub-linearly but positively up to a moderate
+// thread count.
+func SearchLazySMP(main *Search) (int32, Move) {
+	if Threads <= 1 {
+		return main.Search()
+	}
+
+	var stop int32
+	main.SetStopSignal(&stop)
+
+	atomic.StoreInt32(&ttSMPActive, 1)
+	defer atomic.StoreInt32(&ttSMPActive, 0)
+
+	var wg sync.WaitGroup
+	for i := 1; i < Threads; i++ {
+		helper := &Search{
+			MaxDepth:  main.MaxDepth,
+			TimeLimit: main.TimeLimit,
+			silent:    true,
+		}
+		helper.Init(&main.Pos)
+		helper.SetStopSignal(&stop)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			helper.Search()
+		}()
+	}
+
+	score, move := main.Search()
+
+	atomic.StoreInt32(&stop, 1)
+	wg.Wait()
+
+	return score, move
+}

--- a/engine/tt.go
+++ b/engine/tt.go
@@ -1,10 +1,24 @@
 package engine
 
+import (
+	"sync"
+	"sync/atomic"
+)
+
 // Transposition table: caches search results keyed by Position.Hash, so a
 // position reached by a different move order is not re-searched from
 // scratch, and (usually the bigger win) so the best move found last time is
 // available to order search at every node on every iterative-deepening
 // pass.
+//
+// Lazy SMP (see smp.go) shares this table across search goroutines with no
+// synchronization on individual reads/writes other than the shard locks
+// below -- torn reads are caught by the Key check (a torn read essentially
+// never coincides with a matching key), so any surviving corruption just
+// looks like an ordinary probe miss. The shard locks exist only to stop the
+// Go race detector/runtime from tripping over concurrent struct read/write
+// (a real data race on a multi-word struct in Go, unlike on e.g. x86 with
+// aligned words), not because the entry needs to be logically atomic.
 
 const (
 	BoundNone uint8 = iota
@@ -31,6 +45,20 @@ const ttEntrySize = 32 // approx size of TTEntry in bytes, rounded up to a power
 var tt []TTEntry
 var ttMask uint64
 
+// ttShardBits sizes the shard-lock array well below any realistic table size
+// (TTSizeMB=16 gives ~2^19 entries), so lock contention is spread across
+// many shards rather than funneling through one mutex.
+const ttShardBits = 10
+const ttNumShards = 1 << ttShardBits
+
+var ttLocks [ttNumShards]sync.Mutex
+
+// ttSMPActive gates shard locking entirely. Single-threaded search (the
+// common case -- Threads=1) never touches this, so it pays no locking cost
+// at all; it's flipped on only around a multi-goroutine Lazy SMP search (see
+// smp.go).
+var ttSMPActive int32
+
 // allocTT allocates the transposition table. Called from Init().
 func allocTT(sizeMB int) {
 	numEntries := sizeMB * 1024 * 1024 / ttEntrySize
@@ -56,7 +84,18 @@ func ClearTT() {
 // Move field is usable for ordering even when the caller can't use the
 // score itself (e.g. insufficient stored depth).
 func TTProbe(key uint64) (TTEntry, bool) {
-	e := tt[key&ttMask]
+	idx := key & ttMask
+	if atomic.LoadInt32(&ttSMPActive) != 0 {
+		mu := &ttLocks[idx&(ttNumShards-1)]
+		mu.Lock()
+		e := tt[idx]
+		mu.Unlock()
+		if e.Bound == BoundNone || e.Key != key {
+			return TTEntry{}, false
+		}
+		return e, true
+	}
+	e := tt[idx]
 	if e.Bound == BoundNone || e.Key != key {
 		return TTEntry{}, false
 	}
@@ -70,15 +109,21 @@ func TTProbe(key uint64) (TTEntry, bool) {
 // least as deep a search as what's already there.
 func TTStore(key uint64, move Move, score int32, depth int, bound uint8) {
 	idx := key & ttMask
+	entry := TTEntry{
+		Key:   key,
+		Move:  move & 0xffff,
+		Score: score,
+		Depth: int16(depth),
+		Bound: bound,
+	}
+	if atomic.LoadInt32(&ttSMPActive) != 0 {
+		mu := &ttLocks[idx&(ttNumShards-1)]
+		mu.Lock()
+		defer mu.Unlock()
+	}
 	existing := &tt[idx]
 	if existing.Bound == BoundNone || existing.Key != key || int16(depth) >= existing.Depth {
-		*existing = TTEntry{
-			Key:   key,
-			Move:  move & 0xffff,
-			Score: score,
-			Depth: int16(depth),
-			Bound: bound,
-		}
+		*existing = entry
 	}
 }
 

--- a/engine/uci.go
+++ b/engine/uci.go
@@ -295,4 +295,5 @@ func UciSetEngineName(name string) {
 // after `id`/before `uciok`, per the UCI spec.
 func UciOptions() {
 	fmt.Printf("option name EvalFile type string default %s\n", EvalFileDefaultLabel)
+	fmt.Printf("option name Threads type spin default 1 min 1 max 64\n")
 }

--- a/tools/sprt_run.sh
+++ b/tools/sprt_run.sh
@@ -10,6 +10,8 @@
 # Options:
 #   -a, --ref-a REF         Git ref/branch for engine A (default: current branch)
 #   -b, --ref-b REF         Git ref/branch for engine B (default: master)
+#       --opt-a "X=Y,..."   UCI options for engine A, e.g. "Threads=4"
+#       --opt-b "X=Y,..."   UCI options for engine B
 #       --elo0 N            SPRT lower bound, "nothing to see" hypothesis (default: 0)
 #       --elo1 N            SPRT upper bound, "worth it" hypothesis (default: 5)
 #   -n, --rounds N          Max rounds, 2 games/round with colors swapped (default: 800)
@@ -47,11 +49,15 @@ TC="10+0.1"
 HOST="orca"
 LABEL=""
 WAIT=1
+OPT_A=""
+OPT_B=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -a|--ref-a) REF_A="$2"; shift 2 ;;
     -b|--ref-b) REF_B="$2"; shift 2 ;;
+    --opt-a) OPT_A="$2"; shift 2 ;;
+    --opt-b) OPT_B="$2"; shift 2 ;;
     --elo0) ELO0="$2"; shift 2 ;;
     --elo1) ELO1="$2"; shift 2 ;;
     -n|--rounds) ROUNDS="$2"; shift 2 ;;
@@ -65,6 +71,19 @@ while [[ $# -gt 0 ]]; do
     *) echo "unknown option: $1" >&2; exit 1 ;;
   esac
 done
+
+# opt_flags converts "X=Y,Z=W" into " option.X=Y option.Z=W" (leading space,
+# empty string for no options) for appending to a fastchess -engine line.
+opt_flags() {
+  local spec="$1"
+  [[ -z "$spec" ]] && return 0
+  local out="" pair
+  IFS=',' read -ra pairs <<< "$spec"
+  for pair in "${pairs[@]}"; do
+    out+=" option.${pair}"
+  done
+  echo "$out"
+}
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
@@ -136,8 +155,8 @@ if [[ "$HOST" == "orca" ]]; then
   # even though the remote process detaches fine -- backgrounding locally
   # and giving it a moment is the workaround.
   ssh orca "cd ~/sprt && nohup ./fastchess/fastchess \
-    -engine cmd=engines/silverfish_${LABEL}_a name=$NAME_A \
-    -engine cmd=engines/silverfish_${LABEL}_b name=$NAME_B \
+    -engine cmd=engines/silverfish_${LABEL}_a name=$NAME_A$(opt_flags "$OPT_A") \
+    -engine cmd=engines/silverfish_${LABEL}_b name=$NAME_B$(opt_flags "$OPT_B") \
     -each tc=$TC \
     -openings file=books/8moves_v3.pgn format=pgn order=random \
     -rounds $ROUNDS -games 2 -repeat \
@@ -188,8 +207,8 @@ else
   LOGFILE="$(mktemp -d)/${LABEL}.log"
   echo "-- running fastchess locally (log: $LOGFILE)"
   "$FASTCHESS_BIN" \
-    -engine cmd="$BIN_A" name="$NAME_A" \
-    -engine cmd="$BIN_B" name="$NAME_B" \
+    -engine cmd="$BIN_A" name="$NAME_A"$(opt_flags "$OPT_A") \
+    -engine cmd="$BIN_B" name="$NAME_B"$(opt_flags "$OPT_B") \
     -each tc="$TC" \
     -openings file="$BOOK" format=pgn order=random \
     -rounds "$ROUNDS" -games 2 -repeat \


### PR DESCRIPTION
## Summary
Adds a UCI `Threads` option (default 1, unchanged behavior) implementing classic Lazy SMP: `Threads-1` helper goroutines run the same iterative-deepening search as the main thread, all sharing the package-level TT with no explicit work-splitting or diversification. Diversity comes for free from goroutine scheduling jitter. Only the main thread's own result is trusted for the final bestmove/score — helpers exist purely to enrich the shared TT (extra depth/best-move/bound info) and are silenced (no UCI `info` output) and cancelled via a shared atomic stop flag once the main thread concludes.

TT access now goes through 1024 sharded mutexes, but only when `Threads>1` (atomic-gated) — the default single-threaded path takes no lock and is **verified bit-identical in node count to master** at `Threads=1` (fixed-depth startpos search), so this adds zero overhead for anyone not opting in.

Also extends `tools/sprt_run.sh` with `--opt-a`/`--opt-b` flags to set per-engine UCI options via fastchess's `option.X=Y` CLI syntax — needed to compare `Threads=4` against the `Threads=1` baseline (committed as a separate non-strength tooling change).

## Verification before SPRT
- `go build -race` with Threads=4/6: no data races, no crashes/hangs across repeated `go` commands, correct/legal bestmoves, single clean `info` stream (helper threads correctly silenced).
- Threads=1 node counts diffed identical against master at fixed depth.
- Full `go test ./engine/...` green.

## SPRT result
`lazy-smp` (Threads=4) vs `master` (Threads=1), elo0=0/elo1=15, tc=10+0.1, concurrency=8:

**H1 accepted after 180 games** — Elo: +147.19 ± 50.34 (nElo +168.53 ± 50.76), LOS 100.00%, LLR 2.95 (past the 2.94 bound). By far the largest and fastest-confirming search feature this session — makes sense, since Lazy SMP is a different axis from the move-ordering-discipline changes (SEE, PVS, aspiration windows) that all backfired: it parallelizes the existing search rather than changing which moves get searched or in what order.

Note: this result is specific to `Threads=4` on an otherwise-idle 96-core host; real-world gain depends on available cores at deployment/testing time.